### PR TITLE
[refactor] Organize commands into categorical subdirectories

### DIFF
--- a/.claude/commands/agents/AGENT-create-command.md
+++ b/.claude/commands/agents/AGENT-create-command.md
@@ -1,0 +1,1507 @@
+# Create Claude Code Command
+
+<task>
+I want to create a new Claude Code command for the following task: $ARGUMENTS.
+</task>
+
+## Command Creation Guide
+
+### What You'll Create
+
+Claude Code commands are stored prompt templates in Markdown files within the `.claude/commands` folder. Custom slash commands can include the special keyword `$ARGUMENTS` to pass parameters from command invocation.
+
+**Example:** Putting content into `.claude/commands/fix-github-issue.md` makes it available as the `/project:fix-github-issue` command. You could then use `/project:fix-github-issue 1234` to have Claude fix issue #1234.
+
+### Basic Command Structure
+
+```md
+Please analyze and fix the GitHub issue: $ARGUMENTS.
+
+Follow these steps:
+
+1. Use `gh issue view` to get the issue details
+2. Understand the problem described in the issue
+3. Search the codebase for relevant files
+4. Implement the necessary changes to fix the issue
+5. Write and run tests to verify the fix
+6. Ensure code passes linting and type checking
+7. Create a descriptive commit message
+8. Push and create a PR
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.
+```
+
+### Command Locations
+
+You can add commands to:
+- `.claude/commands/` folder for project-specific commands
+- `~/.claude/commands` folder for personal commands available in all sessions
+
+<resources>
+When writing the prompt file, refer to these resources to determine the best way to format, structure, and word the prompt:
+
+- [Prompt Library](https://docs.anthropic.com/en/resources/prompt-library/library)
+- [Claude Code Tutorials](https://docs.anthropic.com/en/docs/claude-code/tutorials)
+</resources>
+
+## Essential Background Information
+
+### Claude Code Overview
+
+Claude Code is an agentic coding assistant that automatically pulls context into prompts. This context gathering consumes time and tokens, but you can optimize it through environment tuning.
+
+#### Create CLAUDE.md files
+
+CLAUDE.md is a special file that Claude automatically pulls into context when starting a conversation. This makes it an ideal place for documenting:
+
+- Common bash commands
+- Core files and utility functions
+- Code style guidelines
+- Testing instructions
+- Repository etiquette (e.g., branch naming, merge vs. rebase, etc.)
+- Developer environment setup (e.g., pyenv use, which compilers work)
+- Any unexpected behaviors or warnings particular to the project
+- Other information you want Claude to remember
+
+There's no required format for CLAUDE.md files. We recommend keeping them concise and human-readable. For example:
+
+```
+# Bash commands
+- npm run build: Build the project
+- npm run typecheck: Run the typechecker
+
+# Code style
+- Use ES modules (import/export) syntax, not CommonJS (require)
+- Destructure imports when possible (eg. import { foo } from 'bar')
+
+# Workflow
+- Be sure to typecheck when you're done making a series of code changes
+- Prefer running single tests, and not the whole test suite, for performance
+```
+
+You can place CLAUDE.md files in several locations:
+
+- The root of your repo, or wherever you run claude from (the most common usage). Name it CLAUDE.md and check it into git so that you can share it across sessions and with your team (recommended), or name it CLAUDE.local.md and .gitignore it
+- Any parent of the directory where you run claude. This is most useful for monorepos, where you might run claude from root/foo, and have CLAUDE.md files in both root/CLAUDE.md and root/foo/CLAUDE.md. Both of these will be pulled into context automatically
+- Any child of the directory where you run claude. This is the inverse of the above, and in this case, Claude will pull in CLAUDE.md files on demand when you work with files in child directories
+- Your home folder (~/.claude/CLAUDE.md), which applies it to all your claude sessions
+
+When you run the /init command, Claude will automatically generate a CLAUDE.md for you.
+
+#### Tune your CLAUDE.md files
+
+Your CLAUDE.md files become part of Claude's prompts, so they should be refined like any frequently used prompt. A common mistake is adding extensive content without iterating on its effectiveness. Take time to experiment and determine what produces the best instruction following from the model.
+
+You can add content to your CLAUDE.md manually or press the # key to give Claude an instruction that it will automatically incorporate into the relevant CLAUDE.md. Many engineers use # frequently to document commands, files, and style guidelines while coding, then include CLAUDE.md changes in commits so team members benefit as well.
+
+At Anthropic, we occasionally run CLAUDE.md files through the prompt improver and often tune instructions (e.g. adding emphasis with "IMPORTANT" or "YOU MUST") to improve adherence.
+
+## Advanced Prompting Reference
+
+<note>
+The following comprehensive prompting guide will help you create effective commands. Apply these principles when crafting your command prompt.
+</note>
+
+### 1. Be Direct
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When interacting with Claude, think of it as a brilliant but very new employee (with amnesia) who needs explicit instructions. Like any new employee, Claude does not have context on your norms, styles, guidelines, or preferred ways of working.
+The more precisely you explain what you want, the better Claude's response will be.
+
+<Tip>**The golden rule of clear prompting**<br />Show your prompt to a colleague, ideally someone who has minimal context on the task, and ask them to follow the instructions. If they're confused, Claude will likely be too.</Tip>
+
+#### How to be clear, contextual, and specific
+
+- **Give Claude contextual information:** Just like you might be able to better perform on a task if you knew more context, Claude will perform better if it has more contextual information. Some examples of contextual information:
+  - What the task results will be used for
+  - What audience the output is meant for
+  - What workflow the task is a part of, and where this task belongs in that workflow
+  - The end goal of the task, or what a successful task completion looks like
+- **Be specific about what you want Claude to do:** For example, if you want Claude to output only code and nothing else, say so.
+- **Provide instructions as sequential steps:** Use numbered lists or bullet points to better ensure that Claude carries out the task the exact way you want it to.
+
+#### The "Manager" Approach: Hyper-Detailed Prompts
+
+For complex agent systems, treat Claude like a new employee who needs comprehensive training. Leading AI startups like Parahelp use prompts that are 6+ pages long, meticulously outlining:
+
+- **Detailed role definition:** Exactly who Claude is and what expertise it should demonstrate
+- **Comprehensive task breakdown:** Every step, decision point, and contingency 
+- **Explicit constraints and guidelines:** What Claude should and shouldn't do
+- **Output format specifications:** Exact structure, formatting, and required elements
+- **Error handling procedures:** How to respond when information is missing or unclear
+
+This approach significantly improves reliability for complex agent workflows, though it requires more upfront investment in prompt development.
+
+#### Implement an "Escape Hatch"
+
+Always instruct Claude to explicitly state when it doesn't know something or lacks sufficient information, rather than hallucinating or making assumptions:
+
+```
+If you do not have enough information to make a determination, say "I don't know" and ask for clarification. Never guess or make up information.
+```
+
+This reduces incorrect outputs and improves trustworthiness in agent systems.
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Anonymizing customer feedback">
+    Notice that Claude still makes mistakes in the unclear prompting example, such as leaving in a customer's name.
+
+    | Role                          | Unclear Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Clear Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                          | Please remove all personally identifiable information from these customer feedback messages: \{\{FEEDBACK\_DATA}}                                                                                                                                                                                                                                                                                                                                                     | Your task is to anonymize customer feedback for our quarterly review.<br /><br />Instructions:<br />1. Replace all customer names with "CUSTOMER\_\[ID]" (e.g., "Jane Doe" → "CUSTOMER\_001").<br />2. Replace email addresses with "EMAIL\_\[ID]@example.com".<br />3. Redact phone numbers as "PHONE\_\[ID]".<br />4. If a message mentions a specific product (e.g., "AcmeCloud"), leave it intact.<br />5. If no PII is found, copy the message verbatim.<br />6. Output only the processed messages, separated by "---".<br /><br />Data to process: \{\{FEEDBACK\_DATA}} |
+    | Assistant (Claude's response) | Here are the anonymized customer feedback messages:<br />1. I've been using your software for years, and it's been great. But lately, AcmeCloud has been crashing a lot. Fix it!<br />2. XXX, your customer support rep, was incredibly helpful. He guided me through the whole process. My email is XXX if you want to send a survey.<br />3. I'm John Smith, and I'm not happy. I've been on hold for 2 hours trying to reach someone at XXX. This is unacceptable! | CUSTOMER\_001: I've been using your software for years, and it's been great. But lately, AcmeCloud has been crashing a lot. Fix it!<br />---<br />CUSTOMER\_002: CUSTOMER\_SERVICE\_001, your customer support rep, was incredibly helpful. He guided me through the whole process. My email is [EMAIL\_002@example.com](mailto:EMAIL_002@example.com) if you want to send a survey.<br />---<br />CUSTOMER\_003: I'm CUSTOMER\_003, and I'm not happy. I've been on hold for 2 hours trying to reach someone at PHONE\_001. This is unacceptable!                             |
+
+  </Accordion>
+
+  <Accordion title="Example: Crafting a marketing email campaign">
+    Notice that Claude makes up details to fill in the gaps where it lacks context with the vague prompt.
+
+    | Role                          | Vague Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Specific Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Write a marketing email for our new AcmeCloud features.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Your task is to craft a targeted marketing email for our Q3 AcmeCloud feature release.<br /><br />Instructions:<br />1. Write for this target audience: Mid-size tech companies (100-500 employees) upgrading from on-prem to cloud.<br />2. Highlight 3 key new features: advanced data encryption, cross-platform sync, and real-time collaboration.<br />3. Tone: Professional yet approachable. Emphasize security, efficiency, and teamwork.<br />4. Include a clear CTA: Free 30-day trial with priority onboarding.<br />5. Subject line: Under 50 chars, mention "security" and "collaboration".<br />6. Personalization: Use \{\{COMPANY\_NAME}} and \{\{CONTACT\_NAME}} variables.<br /><br />Structure:<br />1. Subject line<br />2. Email body (150-200 words)<br />3. CTA button text                                                                                                                                                                                                                                                                                                                                                        |
+    | Assistant (Claude's response) | Here's a draft marketing email for our new features:<br /><br />Subject: Boost Your Business with AcmeCloud's Latest Features<br /><br />Dear Valued Customer,<br /><br />We're excited to introduce three powerful features to AcmeCloud that will revolutionize your workflow:<br /><br />1. Real-Time Collaboration: Work on documents simultaneously with your team. No more version control issues!<br />2. AI-Powered Insights: Make data-driven decisions with AI that analyzes trends and automates tasks.<br />3. Advanced Security Suite: End-to-end encryption, multi-factor auth, and threat detection keep your data safe.<br /><br />Limited Offer: Upgrade now for a 20% first-year discount. Plus, refer a friend for an extra 10% off!<br /><br />Best,<br />The AcmeCloud Team | Subject line: AcmeCloud: Enterprise security meets real-time teamwork<br /><br />Email body:<br />Dear \{\{CONTACT\_NAME}},<br /><br />At \{\{COMPANY\_NAME}}, you're scaling fast and eyeing the cloud. But with growth comes the challenge of keeping data secure while fostering collaboration. That's where AcmeCloud's Q3 release comes in, tailor-made for tech innovators like you.<br /><br />1. Fort Knox for Your Files: Military-grade encryption now safeguards your data, both in motion and at rest. Your intellectual property stays yours, period.<br />2. Sync Without Borders: Windows, Mac, or Linux—AcmeCloud speaks all languages. Unified version control means no more "final\_v2\_REALLY\_FINAL.doc".<br />3. Collaborate at Light Speed: Ditch the attachment ping-pong. Now your devs, designers, and data scientists co-create in real-time, slashing time-to-market.<br /><br />Don't just take our word for it. Experience the AcmeCloud difference with our 30-day trial. And because we know time is your most precious asset, we're throwing in priority onboarding.<br /><br />Elevate Your Team Now - Free 30-Day Trial |
+
+  </Accordion>
+
+  <Accordion title="Example: Incident response">
+    Notice that Claude outputs superfluous text and different formatting with the vague prompt.
+
+    | Role                          | Vague Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Detailed Prompt                                                                                                                                                                                                                                                                                                         |
+    | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Analyze this AcmeCloud outage report and summarize the key points.<br /><br />\{\{REPORT}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Analyze this AcmeCloud outage report. Skip the preamble. Keep your response terse and write only the bare bones necessary information. List only:<br />1) Cause<br />2) Duration<br />3) Impacted services<br />4) Number of affected users<br />5) Estimated revenue loss. <br /><br />Here's the report: \{\{REPORT}} |
+    | Assistant (Claude's response) | Here's a summary of the key points from the AcmeCloud outage report:<br /><br />On May 15th, a misconfigured load balancer update caused significant traffic routing issues, resulting in a service outage from 09:15 to 13:52 UTC. The 4-hour 37-minute disruption impacted our core file syncing service and admin dashboard, rendering them inaccessible. Additionally, the mobile app experienced partial functionality loss. Approximately 68% of our user base, totaling 1.3 million users, were affected. Based on our Service Level Agreements (SLAs) and average revenue per user, we estimate a financial impact of \$420,000 in service credits and potential customer churn. | 1) Cause: Misconfigured load balancer update<br />2) Duration: 4h 37m (09:15-13:52 UTC, May 15)<br />3) Impacted: Core sync, admin dashboard (down); mobile app (partial)<br />4) Affected users: 1.3M (68% of base)<br />5) Est. revenue loss: \$420,000                                                               |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 2. Use Examples (Multishot Prompting)
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+Examples are your secret weapon shortcut for getting Claude to generate exactly what you need. By providing a few well-crafted examples in your prompt, you can dramatically improve the accuracy, consistency, and quality of Claude's outputs.
+This technique, known as few-shot or multishot prompting, is particularly effective for tasks that require structured outputs or adherence to specific formats.
+
+<Tip>**Power up your prompts**: Include 3-5 diverse, relevant examples to show Claude exactly what you want. More examples = better performance, especially for complex tasks.</Tip>
+
+#### Why use examples?
+
+- **Accuracy**: Examples reduce misinterpretation of instructions.
+- **Consistency**: Examples enforce uniform structure and style.
+- **Performance**: Well-chosen examples boost Claude's ability to handle complex tasks.
+
+#### Crafting effective examples
+
+For maximum effectiveness, make sure that your examples are:
+
+- **Relevant**: Your examples mirror your actual use case.
+- **Diverse**: Your examples cover edge cases and potential challenges, and vary enough that Claude doesn't inadvertently pick up on unintended patterns.
+- **Clear**: Your examples are wrapped in `<example>` tags (if multiple, nested within `<examples>` tags) for structure.
+
+<Tip>Ask Claude to evaluate your examples for relevance, diversity, or clarity. Or have Claude generate more examples based on your initial set.</Tip>
+
+<Accordion title="Example: Analyzing customer feedback">
+  Notice that in the "no examples" version, Claude does not list multiple options for each category, despite its written analysis indicating that there are multiple categories for certain feedback. It also includes a long explanation when we may not want it to.
+
+| Role                          | No Examples                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | With Examples                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User                          | Analyze this customer feedback and categorize the issues. Use these categories: UI/UX, Performance, Feature Request, Integration, Pricing, and Other. Also rate the sentiment (Positive/Neutral/Negative) and priority (High/Medium/Low).<br /><br />Here is the feedback: \{\{FEEDBACK}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Our CS team is overwhelmed with unstructured feedback. Your task is to analyze feedback and categorize issues for our product and engineering teams. Use these categories: UI/UX, Performance, Feature Request, Integration, Pricing, and Other. Also rate the sentiment (Positive/Neutral/Negative) and priority (High/Medium/Low). Here is an example:<br /><br />\<example><br />Input: The new dashboard is a mess! It takes forever to load, and I can't find the export button. Fix this ASAP!<br />Category: UI/UX, Performance<br />Sentiment: Negative<br />Priority: High\</example><br /><br />Now, analyze this feedback: \{\{FEEDBACK}}                                                                                                                                                                                                                                                                                                                                                                                               |
+| Assistant (Claude's response) | Here's the analysis of the customer feedback:<br /><br />Issue: UI/UX<br />Sentiment: Negative<br />Priority: High<br />The customer is frustrated with the new dashboard design, which they find cluttered and slow to load. They specifically call out the missing "export" button, which is likely a critical feature. This issue needs to be addressed as a high priority.<br /><br />Issue: Integration<br />Sentiment: Positive<br />Priority: Medium<br />The customer is pleased with the existing Salesforce integration but would like to see support for Hubspot as well. This is a feature request that could be considered for a future product update.<br /><br />Issue: Pricing<br />Sentiment: Negative<br />Priority: High<br />The customer finds the pricing to be unreasonable, especially for the basic features. They are threatening to switch to a competitor, so this is a high-priority issue that needs to be reviewed.<br /><br />Issue: Performance<br />Sentiment Negative<br />Priority: High<br />The customer is experiencing critical issues with the mobile app, where large file uploads consistently result in crashes. This is a significant problem that impacts the customer's ability to use the product effectively and should be addressed as a high priority.<br /><br />Issue: UI/UX<br />Sentiment: Positive<br />Priority: Low<br />The customer is overall satisfied with the product, specifically calling out the intuitive UI and excellent customer support. This is a positive piece of feedback that does not require any immediate action. | Here's the analysis of the customer feedback:<br /><br />1. The new dashboard is a mess! It takes forever to load, and I can't find the export button. Fix this ASAP!<br />Category: UI/UX, Performance<br />Sentiment: Negative<br />Priority: High<br /><br />2. Love the Salesforce integration! But it'd be great if you could add Hubspot too.<br />Category: Integration, Feature Request<br />Sentiment: Positive<br />Priority: Medium<br /><br />3. Your pricing is ridiculous! \$99/mo for basic features? I'm switching to Competitor X.<br />Category: Pricing<br />Sentiment: Negative<br />Priority: High<br /><br />4. The mobile app keeps crashing when I try to upload large files (>50MB). This is critical for our field agents.<br />Category: Performance<br />Sentiment: Negative<br />Priority: High<br /><br />5. Overall, I'm happy with the product. The UI is intuitive, and the customer support is top-notch. Keep it up!<br />Category: UI/UX, Other (Customer Support)<br />Sentiment: Positive<br />Priority: Low |
+
+</Accordion>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 3. Let Claude Think (Chain of Thought Prompting)
+
+When tackling complex problems, allow Claude to work through them step by step. This approach, known as chain of thought prompting, often leads to more accurate and thoughtful responses. The model can break down complex tasks, reason through different approaches, and arrive at better solutions.
+
+### 4. Use XML Tags to Structure Your Prompts
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When your prompts involve multiple components like context, instructions, and examples, XML tags can be a game-changer. They help Claude parse your prompts more accurately, leading to higher-quality outputs.
+
+<Tip>**XML tip**: Use tags like `<instructions>`, `<example>`, and `<formatting>` to clearly separate different parts of your prompt. This prevents Claude from mixing up instructions with examples or context.</Tip>
+
+#### Why use XML tags?
+
+- **Clarity:** Clearly separate different parts of your prompt and ensure your prompt is well structured.
+- **Accuracy:** Reduce errors caused by Claude misinterpreting parts of your prompt.
+- **Flexibility:** Easily find, add, remove, or modify parts of your prompt without rewriting everything.
+- **Parseability:** Having Claude use XML tags in its output makes it easier to extract specific parts of its response by post-processing.
+
+<Note>There are no canonical "best" XML tags that Claude has been trained with in particular, although we recommend that your tag names make sense with the information they surround.</Note>
+
+#### Tagging best practices
+
+1. **Be consistent**: Use the same tag names throughout your prompts, and refer to those tag names when talking about the content (e.g, `Using the contract in <contract> tags...`).
+2. **Nest tags**: You should nest tags `<outer><inner></inner></outer>` for hierarchical content.
+
+<Tip>**Power user tip**: Combine XML tags with other techniques like multishot prompting (`<examples>`) or chain of thought (`<thinking>`, `<answer>`). This creates super-structured, high-performance prompts.</Tip>
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Generating financial reports">
+    Without XML tags, Claude misunderstands the task and generates a report that doesn't match the required structure or tone. After substitution, there is also a chance that Claude misunderstands where one section (like the Q1 report example) stops and another begins.
+
+    | Role      | No XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | With XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+    | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | You're a financial analyst at AcmeCorp. Generate a Q2 financial report for our investors. Include sections on Revenue Growth, Profit Margins, and Cash Flow, like with this example from last year: \{\{Q1\_REPORT}}. Use data points from this spreadsheet: \{\{SPREADSHEET\_DATA}}. The report should be extremely concise, to the point, professional, and in list format. It should and highlight both strengths and areas for improvement.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | You're a financial analyst at AcmeCorp. Generate a Q2 financial report for our investors.<br /><br />AcmeCorp is a B2B SaaS company. Our investors value transparency and actionable insights.<br /><br />Use this data for your report:\<data>\{\{SPREADSHEET\_DATA}}\</data><br /><br />\<instructions><br />1. Include sections: Revenue Growth, Profit Margins, Cash Flow.<br />2. Highlight strengths and areas for improvement.<br />\</instructions><br /><br />Make your tone concise and professional. Follow this structure:<br />\<formatting\_example>\{\{Q1\_REPORT}}\</formatting\_example>                                                                                                                                                                                                                  |
+    | Assistant | Q2 Financial Report for AcmeCorp Investors<br /><br />Dear Valued Investors,<br /><br />I am pleased to present our Q2 financial report, showcasing AcmeCorp's continued growth and resilience in the B2B SaaS market.<br /><br />1. Revenue Growth:<br />Our Q2 revenue reached \$15.2M, a 22% YoY increase. This growth is primarily driven by a 30% expansion in our enterprise client base. However, our SMB segment saw a slight decline of 5%, which we aim to address through targeted marketing initiatives in Q3.<br /><br />2. Profit Margins:<br />Gross margin improved to 72% (up 3% from Q1) due to infrastructure optimizations. EBITDA margin, however, dipped to 18% (down 2%) as we invested heavily in R\&D for our upcoming AI-driven features.<br /><br />3. Cash Flow:<br />Operating cash flow remains strong at \$4.1M. Our cash reserves stand at \$28M, providing a 15-month runway at current burn rate. We did see a 20% increase in customer acquisition costs, which we're addressing through more efficient sales strategies.<br /><br />In summary, AcmeCorp's core financials remain robust. We're balancing growth investments with prudent cash management. Our focus for Q3 will be revitalizing SMB growth and optimizing sales efficiency.<br /><br />Thank you for your continued trust.<br /><br />Sincerely,<br />CFO, AcmeCorp | Q2 Financial Report for AcmeCorp Investors\</output><br /><br />Revenue Growth:<br />- Q2 revenue: \$15.2M (22% YoY ↑)<br />- Enterprise clients: 30% ↑<br />- SMB segment: 5% ↓<br />  Action: Targeted Q3 marketing<br /><br />Profit Margins:<br />- Gross margin: 72% (3% ↑ from Q1)<br />  Reason: Infrastructure optimizations<br />- EBITDA margin: 18% (2% ↓)<br />  Reason: R\&D investment in AI features<br /><br />Cash Flow:<br />- Operating cash flow: \$4.1M (strong)<br />- Cash reserves: \$28M (15-month runway)<br />- Customer acquisition cost: 20% ↑<br />  Action: Optimize sales strategies<br /><br />Outlook:<br />- Core financials: Robust<br />- Q3 focus: Revitalize SMB, optimize sales<br /><br />Management remains committed to balancing growth investments with financial discipline. |
+
+  </Accordion>
+
+  <Accordion title="Example: Legal contract analysis">
+    Without XML tags, Claude's analysis is disorganized and misses key points. With tags, it provides a structured, thorough analysis that a legal team can act on.
+
+    | Role      | No XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | With XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+    | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User      | Analyze this software licensing agreement for potential risks and liabilities: \{\{CONTRACT}}. Focus on indemnification, limitation of liability, and IP ownership clauses. Also, note any unusual or concerning terms. Here's our standard contract for reference: \{\{STANDARD\_CONTRACT}}. Give a summary of findings and recommendations for our legal team.                                                                                                                                                                                                                                                                                                                    | Analyze this software licensing agreement for legal risks and liabilities.<br /><br />We're a multinational enterprise considering this agreement for our core data infrastructure.<br /><br />\<agreement><br />\{\{CONTRACT}}\</agreement><br /><br />This is our standard contract for reference:<br />\<standard\_contract>\{\{STANDARD\_CONTRACT}}\</standard\_contract><br /><br />\<instructions><br />1. Analyze these clauses:<br />   - Indemnification<br />   - Limitation of liability<br />   - IP ownership<br /><br />2. Note unusual or concerning terms.<br /><br />3. Compare to our standard contract.<br /><br />4. Summarize findings in \<findings> tags.<br /><br />5. List actionable recommendations in \<recommendations> tags.\</instructions>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+    | Assistant | The provided software licensing agreement presents several concerning aspects. The indemnification clause is overly broad, potentially exposing us to significant liabilities. The limitation of liability section caps damages at a mere \$500, which is inadequate for our enterprise-level usage. Regarding IP, the agreement grants the vendor joint ownership of any modifications or integrations we create.<br /><br />In summary, this agreement is not in our best interest. It exposes us to undue risk, limits our recourse in case of failures, and compromises our intellectual property rights. I recommend renegotiating these terms or seeking alternative vendors. | \<findings><br />1. Indemnification (Clause 8):<br />   - Issue: Overly broad. We indemnify vendor against "any and all claims" arising from our use.<br />   - Risk: Could hold us liable even for vendor's negligence or product defects.<br />   - Deviation: Our standard limits indemnity to claims arising from our violation of agreement.<br /><br />2. Limitation of Liability (Clause 9):<br />   - Issue: Caps all damages at \$500, including direct damages.<br />   - Risk: Grossly inadequate for enterprise use. A critical failure could cost millions.<br />   - Deviation: Our standard allows for direct damages up to 12 months of fees paid.<br /><br />3. IP Ownership (Clause 12):<br />   - Issue: Grants vendor joint ownership of our modifications/integrations.<br />   - Risk: Vendor could use or sell our proprietary algorithms or data insights.<br />   - Deviation: Our standard retains full ownership of our work.<br /><br />4. Unusual Terms:<br />   - Clause 5.3: Vendor can use our usage data for "any purpose."<br />   - Clause 7.2: Vendor can terminate for "convenience" with only 7 days' notice.<br />   - Clause 11: No warranties of any kind, even for basic merchantability.<br />\</findings><br /><br />\<recommendations><br />1. Reject this agreement. Risks far outweigh benefits for an enterprise.<br />2. Counter-propose:<br />   - Indemnification: Limit to claims arising from our violation of agreement.<br />   - Liability: Cap at 12 months' fees for direct damages; negotiate for indirect.<br />   - IP: Full ownership of our modifications/integrations.<br />   - Data Use: Restrict to service improvement only.<br />   - Termination: Minimum 90 days' notice; only for cause.<br />   - Warranties: Demand basic merchantability and fitness for purpose.<br />3. If vendor refuses, explore alternative providers or in-house solutions.<br />4. Engage legal counsel for contract negotiation given high stakes.<br />\</recommendations> |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 5. Give Claude a Role with a System Prompt
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When using Claude, you can dramatically improve its performance by using the `system` parameter to give it a role. This technique, known as role prompting, is the most powerful way to use system prompts with Claude.
+
+The right role can turn Claude from a general assistant into your virtual domain expert!
+
+<Tip>**System prompt tips**: Use the `system` parameter to set Claude's role. Put everything else, like task-specific instructions, in the `user` turn instead.</Tip>
+
+#### Why use role prompting?
+
+- **Enhanced accuracy:** In complex scenarios like legal analysis or financial modeling, role prompting can significantly boost Claude's performance.
+- **Tailored tone:** Whether you need a CFO's brevity or a copywriter's flair, role prompting adjusts Claude's communication style.
+- **Improved focus:** By setting the role context, Claude stays more within the bounds of your task's specific requirements.
+
+#### How to give Claude a role
+
+Use the `system` parameter in the [Messages API](/en/api/messages) to set Claude's role:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-3-7-sonnet-20250219",
+    max_tokens=2048,
+    system="You are a seasoned data scientist at a Fortune 500 company.", # <-- role prompt
+    messages=[
+        {"role": "user", "content": "Analyze this dataset for anomalies: <dataset>{{DATASET}}</dataset>"}
+    ]
+)
+
+print(response.content)
+```
+
+<Tip>**Role prompting tip**: Experiment with roles! A `data scientist` might see different insights than a `marketing strategist` for the same data. A `data scientist specializing in customer insight analysis for Fortune 500 companies` might yield different results still!</Tip>
+
+#### Examples
+
+##### Example 1: Legal contract analysis
+
+Without a role, Claude might miss critical issues:
+
+<Accordion title="Legal contract analysis without role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | Analyze this software licensing agreement for potential risks:<br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Focus on indemnification, liability, and IP ownership.                                                                                                                                                                                                                                                                                                                              |
+  | Assistant | Here's a summary of the key points in the software licensing agreement:<br /><br />1. Indemnification (Section 8):<br />   - We indemnify the vendor against claims arising from our use.<br /><br />2. Limitation of Liability (Section 9):<br />   - Damages capped at \$500.<br /><br />3. IP Ownership (Section 12):<br />   - We retain ownership of our modifications.<br /><br />Overall, the agreement seems standard. The indemnification and liability clauses are typical, and we maintain our IP rights. |
+</Accordion>
+
+With a role, Claude catches critical issues that could cost millions:
+
+<Accordion title="Legal contract analysis with role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+  | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | You are the General Counsel of a Fortune 500 tech company. We're considering this software licensing agreement for our core data infrastructure:<br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Analyze it for potential risks, focusing on indemnification, liability, and IP ownership. Give your professional opinion.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+  | Assistant | I've reviewed the software licensing agreement, and I have serious concerns that could expose our company to significant risks:<br /><br />1. Indemnification (Section 8):<br />   - Critical Issue: We indemnify the vendor against "any and all claims" arising from our use.<br />   - Risk: This could hold us liable even for the vendor's negligence or product defects.<br />   - Recommendation: Reject. Limit our indemnity to claims arising from our violation of the agreement.<br /><br />2. Limitation of Liability (Section 9):<br />   - Critical Issue: Damages capped at \$500, including direct damages.<br />   - Risk: Grossly inadequate. A critical failure in our data infrastructure could cost us millions in lost revenue and reputational damage.<br />   - Recommendation: Reject. Negotiate for cap at 12 months of fees for direct damages, and carve-outs for data breaches.<br /><br />3. IP Ownership (Section 12):<br />   - Critical Issue: Vendor gains joint ownership of our modifications and integrations.<br />   - Risk: They could use or sell our proprietary algorithms or data insights to competitors.<br />   - Recommendation: Reject. We must retain full ownership of our work.<br /><br />Professional Opinion: Do not sign this agreement. It is grossly unfavorable and exposes us to unacceptable levels of risk. If the vendor refuses to renegotiate these terms, I strongly advise exploring alternative providers or accelerating our in-house solution. The potential costs of proceeding with this agreement far outweigh any short-term gains. |
+</Accordion>
+
+##### Example 2: Financial analysis
+
+Without a role, Claude's analysis lacks depth:
+
+<Accordion title="Financial analysis without role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | Analyze this dataset of our Q2 financials:<br />\<data><br />\{\{FINANCIALS}}<br />\</data><br /><br />Highlight key trends and recommend actions.                                                                                                                                                                                                                                                                                                                               |
+  | Assistant | Here's a summary of your Q2 financials:<br /><br />1. Revenue: \$15.2M, up 22% YoY. Enterprise client base grew 30%.<br />2. Gross Margin: 72%, up 3% from Q1.<br />3. EBITDA Margin: 18%, down 2% due to R\&D investments.<br />4. Cash Flow: \$4.1M operating, \$28M in reserves.<br /><br />Overall, financials look strong with revenue growth and healthy margins. Increased R\&D spending is impacting profitability but could pay off long-term. Maintain current course. |
+</Accordion>
+
+With a role, Claude delivers actionable insights:
+
+<Accordion title="Financial analysis with role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | You are the CFO of a high-growth B2B SaaS company. We're in a board meeting discussing our Q2 financials:<br />\<data><br />\{\{FINANCIALS}}<br />\</data><br /><br />Analyze key trends, flag concerns, and recommend strategic actions. Our investors want aggressive growth but are wary of our burn rate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+  | Assistant | Board members, here's my analysis of our Q2 financials:<br /><br />1. Revenue (\$15.2M, +22% YoY):<br />   - Insight: Enterprise growth (+30%) is outpacing overall growth.<br />   - Flag: SMB segment declined 5%.<br />   - Action: Reallocate 20% of SMB marketing budget to enterprise sales. Task product to simplify SMB onboarding.<br /><br />2. Margins (Gross: 72%, +3% QoQ; EBITDA: 18%, -2% QoQ):<br />   - Insight: Infrastructure optimizations boosted gross margins.<br />   - Flag: R\&D spend on AI features dented EBITDA.<br />   - Action: No change. Our AI roadmap is critical for enterprise stickiness.<br /><br />3. Cash (\$4.1M OCF, \$28M reserves):<br />   - Insight: 15-month runway at current burn.<br />   - Flag: CAC up 20%, eroding LTV/CAC.<br />   - Action: Freeze non-essential hires. Implement sales funnel analytics to cut CAC by 15% in Q3.<br /><br />Strategic Stance: We're threading the needle between growth and burn. Enterprise focus is our growth engine—invest there. But watch SMB churn; it could bleed into enterprise. Our AI bet is sound, but we must convert it to ARR by Q4, or we cut R\&D by 30%.<br /><br />In sum: Double down on enterprise, streamline SMB, optimize sales, and monetize AI. Questions? |
+</Accordion>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 6. Chain Complex Prompts for Stronger Performance
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When working with complex tasks, Claude can sometimes drop the ball if you try to handle everything in a single prompt. Chain of thought (CoT) prompting is great, but what if your task has multiple distinct steps that each require in-depth thought?
+
+Enter prompt chaining: breaking down complex tasks into smaller, manageable subtasks.
+
+#### Why chain prompts?
+
+1. **Accuracy**: Each subtask gets Claude's full attention, reducing errors.
+2. **Clarity**: Simpler subtasks mean clearer instructions and outputs.
+3. **Traceability**: Easily pinpoint and fix issues in your prompt chain.
+
+#### When to chain prompts
+
+Use prompt chaining for multi-step tasks like research synthesis, document analysis, or iterative content creation. When a task involves multiple transformations, citations, or instructions, chaining prevents Claude from dropping or mishandling steps.
+
+**Remember:** Each link in the chain gets Claude's full attention!
+
+<Tip>**Debugging tip**: If Claude misses a step or performs poorly, isolate that step in its own prompt. This lets you fine-tune problematic steps without redoing the entire task.</Tip>
+
+#### How to chain prompts
+
+1. **Identify subtasks**: Break your task into distinct, sequential steps.
+2. **Structure with XML for clear handoffs**: Use XML tags to pass outputs between prompts.
+3. **Have a single-task goal**: Each subtask should have a single, clear objective.
+4. **Iterate**: Refine subtasks based on Claude's performance.
+
+##### Example chained workflows:
+
+- **Multi-step analysis**: See the legal and business examples below.
+- **Content creation pipelines**: Research → Outline → Draft → Edit → Format.
+- **Data processing**: Extract → Transform → Analyze → Visualize.
+- **Decision-making**: Gather info → List options → Analyze each → Recommend.
+- **Verification loops**: Generate content → Review → Refine → Re-review.
+
+<Tip>**Optimization tip**: For tasks with independent subtasks (like analyzing multiple docs), create separate prompts and run them in parallel for speed.</Tip>
+
+##### Prompt Folding & Dynamic Generation
+
+Design prompts that can dynamically generate more specialized sub-prompts based on context or previous outputs in multi-stage workflows. This creates adaptive agentic systems that tailor their approach based on what they discover.
+
+**Example Pattern:**
+1. **Classifier prompt** that analyzes the input and determines the best approach
+2. **Dynamic sub-prompt generation** based on the classification
+3. **Specialized execution** using the generated sub-prompt
+
+```
+Step 1: Analyze this customer query and determine the best response approach.
+If it's a technical issue → generate a detailed troubleshooting prompt
+If it's a billing question → generate a billing-specific prompt  
+If it's a feature request → generate a product feedback prompt
+
+Step 2: Use the generated prompt to handle the specific case
+```
+
+This technique allows for more sophisticated and context-aware agent behaviors.
+
+##### Advanced: Self-correction chains
+
+You can chain prompts to have Claude review its own work! This catches errors and refines outputs, especially for high-stakes tasks.
+
+<AccordionGroup>
+  <Accordion title="Example: Self-correcting research summary">
+    #### Prompt 1
+
+    | Role                         | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+    | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                         | Summarize this medical research paper.<br /><br />\<paper>\{\{RESEARCH\_PAPER}}\</paper><br /><br />Focus on methodology, findings, and clinical implications.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+    | Assistant<br />\{\{SUMMARY}} | Methodology: Double-blind RCT with 500 Type 2 diabetes patients. Group A (n=250) received novel GLP-1/GIP dual agonist; Group B (n=250) received standard GLP-1 agonist. 24-week trial, primary endpoint: HbA1c reduction.<br /><br />Findings:<br />- Group A: 1.8% mean HbA1c reduction<br />- Group B: 1.1% mean HbA1c reduction<br />- 68% of Group A vs. 52% of Group B achieved HbA1c \<7%<br />- Group A: 5.2kg mean weight loss<br />- Group B: 3.1kg mean weight loss<br /><br />Safety: Similar adverse event profiles, no serious events attributed to treatment.<br /><br />Clinical Implications: Dual agonist shows superior glycemic control and weight loss compared to standard therapy. Could be a game-changer, especially for obese diabetics. |
+
+    #### Prompt 2
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+    | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Your task is to provide feedback on a research paper summary. Here is a summary of a medical research paper:<br />\<summary><br />\{\{SUMMARY}}<br />\</summary><br /><br />Here is the research paper:<br />\<paper><br />\{\{RESEARCH\_PAPER}}<br />\</paper><br /><br />Review this summary for accuracy, clarity, and completeness on a graded A-F scale.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | Assistant<br />\{\{FEEDBACK}} | 1. Accuracy: A<br />   - Correctly reported key stats: HbA1c reductions, weight loss.<br />   - Accurately noted safety profile and lack of serious adverse events.<br />   - Assertion of "game-changer" is justified by significantly better outcomes.<br /><br />2. Clarity: A-<br />   - Concise and well-structured with clear sections.<br />   - Good use of comparative language (e.g., "up 3% from Q1") for context.<br />   - Minor issue: Acronyms like "RCT," "GLP-1," and "GIP" not defined. Consider spelling out first use.<br /><br />3. Completeness: B+<br />   - Covers all requested areas: methodology, findings, clinical implications.<br />   - Missing: Baseline characteristics of groups (were they well-matched?).<br />   - Missing: Any secondary endpoints (e.g., blood pressure, lipids).<br />   - Consider: Long-term implications or need for further research.<br /><br />Overall, the summary is accurate and clear, providing key insights for a quick grasp of the study. To elevate to A+, define acronyms, mention group baseline stats, note any secondary outcomes, and briefly touch on the need for long-term studies. |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | Your task is to improve a paper summary given feedback. Here is the first draft of a medical research paper:<br />\<summary><br />\{\{SUMMARY}}<br />\</summary><br /><br />Here is the research paper:<br />\<paper><br />\{\{RESEARCH\_PAPER}}<br />\</paper><br /><br />Here is the feedback:<br />\<feedback><br />\{\{FEEDBACK}}<br />\</feedback><br /><br />Update the summary based on the feedback.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+    | Assistant | Methodology: Double-blind randomized controlled trial (RCT) with 500 Type 2 diabetes patients. Group A (n=250) received a novel glucagon-like peptide-1/glucose-dependent insulinotropic polypeptide (GLP-1/GIP) dual agonist; Group B (n=250) received a standard GLP-1 agonist. The 24-week trial's primary endpoint was HbA1c reduction. Groups were well-matched for age, BMI, and baseline HbA1c.<br /><br />Findings:<br />- Group A: 1.8% mean HbA1c reduction<br />- Group B: 1.1% mean HbA1c reduction<br />- 68% of Group A vs. 52% of Group B achieved HbA1c \<7%<br />- Group A: 5.2kg mean weight loss<br />- Group B: 3.1kg mean weight loss<br /><br />Secondary endpoints showed improvements in blood pressure and lipid profiles for both groups, with Group A showing slightly better results.<br /><br />Safety: Similar adverse event profiles, with no serious events attributed to either treatment.<br /><br />Clinical Implications: The dual GLP-1/GIP agonist demonstrates superior glycemic control and weight loss compared to standard GLP-1 therapy. These results suggest it could be a significant advancement, particularly for obese diabetics. However, longer-term studies are needed to confirm sustained efficacy and safety, as well as to investigate potential benefits on cardiovascular outcomes. |
+
+  </Accordion>
+</AccordionGroup>
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Analyzing a legal contract (without chaining)">
+    Note that Claude misses the instruction to provide proposed changes in its email draft.
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+    | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | You're our Chief Legal Officer. Review this SaaS contract for risks, focusing on data privacy, SLAs, and liability caps.<br /><br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Then draft an email to the vendor with your concerns and proposed changes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+    | Assistant | After reviewing the SaaS contract, I've identified several concerns:<br /><br />1. Data Privacy (Section 7):<br />   - Issue: Vendor has broad rights to use client data for "service improvement."<br />   - Risk: Could lead to unauthorized data sharing or monetization.<br /><br />2. SLAs (Section 5):<br />   - Issue: 99.5% uptime guarantee is below industry standard.<br />   - Risk: Excessive downtime could impact our operations.<br /><br />3. Liability (Section 9):<br />   - Issue: Cap set at 3 months of fees.<br />   - Risk: Inadequate for potential data breaches or service failures.<br /><br />Draft email:<br /><br />Dear \{\{VENDOR}},<br /><br />After reviewing the SaaS agreement, we have concerns:<br /><br />1. Data Privacy: We require that our data only be used for direct service provision, not broad "service improvement." Please amend Section 7.<br /><br />2. SLAs: 99.5% uptime is insufficient. We need 99.99% with clearly defined penalties. Please revise Section 5.<br /><br />3. Liability: The current cap of 3 months' fees is inadequate. We propose a cap of 12 months' fees, with no cap for data breaches or willful misconduct.<br /><br />We value our potential partnership and believe these changes will set us up for success. Please send a revised agreement.<br /><br />Best regards,<br />\{\{CLO\_NAME}} |
+
+  </Accordion>
+
+  <Accordion title="Example: Analyzing a legal contract (with chaining)">
+    #### Prompt 1
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | You're our Chief Legal Officer. Review this SaaS contract for risks, focusing on data privacy, SLAs, and liability caps.<br /><br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Output your findings in \<risks> tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | Assistant<br />\{\{CONCERNS}} | 1. Data Privacy (Section 7):<br />   - Issue: Vendor has broad rights to use client data for "service improvement."<br />   - Risk: Could lead to unauthorized data sharing or monetization of client data.<br />   - Impact: Potential breach of client trust, regulatory fines (GDPR, CCPA).<br /><br />2. SLAs (Section 5):<br />   - Issue: 99.5% uptime guarantee is below industry standard (typically 99.99%).<br />   - Risk: Up to 43.8 hours of downtime per year vs. 52.6 minutes at 99.99%.<br />   - Impact: Operational disruptions, revenue loss, client dissatisfaction.<br /><br />3. Liability (Section 9):<br />   - Issue: Liability cap set at 3 months of fees.<br />   - Risk: Inadequate for potential data breaches, IP theft, or prolonged service failures.<br />   - Impact: Insufficient compensation for damages that could far exceed the cap, like class-action lawsuits or regulatory fines. |
+
+    #### Prompt 2
+
+    | Role                       | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+    | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                       | Draft an email to a SaaS product vendor outlining the following concerns and proposing changes. Here are the concerns:<br />\<concerns><br />\{\{CONCERNS}}<br />\</concerns><br /><br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | Assistant<br />\{\{EMAIL}} | Dear \{\{VENDOR}},<br /><br />After a thorough review of the proposed SaaS agreement, our legal team has identified several high-priority concerns that must be addressed before we can proceed:<br /><br />1. Data Privacy (Section 7):<br />   - Current: Broad rights to use client data for "service improvement."<br />   - Concern: Potential unauthorized data sharing or monetization.<br />   - Proposed Change: Limit data use to direct service provision. Any use for improvement, analytics, or marketing must be opt-in, revocable, and anonymized.<br /><br />2. SLAs (Section 5):<br />   - Current: 99.5% uptime guarantee.<br />   - Concern: Up to 43.8 hours of downtime per year, risking operational disruptions.<br />   - Proposed Change: 99.99% uptime with tiered service credits. E.g., 10% credit for \<99.99%, 25% for \<99.9%, 50% for \<99.5%.<br /><br />3. Liability (Section 9):<br />   - Current: Cap at 3 months of fees.<br />   - Concern: Grossly inadequate for data breaches, IP theft, or prolonged outages.<br />   - Proposed Change: 12 months' fees for general liability. Uncapped for data breaches, willful misconduct, IP infringement.<br /><br />These changes are non-negotiable for us. They align with industry standards and our commitment to data security, operational excellence, and fiduciary responsibility. We value the potential of our partnership, and addressing these will set a strong foundation.<br /><br />Please have your legal team review and incorporate these changes. We're happy to discuss further to ensure mutual understanding and agreement.<br /><br />Best regards,<br />\{\{CLO\_NAME}} |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+    | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User      | Your task is to review an email and provide feedback. Here is the email:<br />\<email><br />\{\{EMAIL}}<br />\</email><br /><br />Give feedback on tone, clarity, and professionalism.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | Assistant | 1. Tone:<br />   - Professional and assertive without being confrontational.<br />   - Use of "non-negotiable" is strong but justified given the criticality of the issues.<br />   - Collaborative language ("we value," "happy to discuss") balances the firmness, maintaining a constructive tone.<br /><br />2. Clarity:<br />   - Excellent structuring: Current state, concern, and proposed change for each issue.<br />   - Technical terms (e.g., "EBITDA," "tiered service credits") are appropriate for a B2B SaaS context.<br />   - Action items are clear: vendor's legal team to review and incorporate changes.<br /><br />3. Professionalism:<br />   - Focuses on mutual benefit and industry standards, not just our demands.<br />   - Mentions broader responsibilities (data security, operational excellence, fiduciary duty), elevating the discussion.<br />   - Offers further discussion, showing commitment to understanding and resolving issues.<br /><br />Overall, the email strikes the right balance of assertiveness and collaboration. It clearly articulates our concerns, proposes specific solutions, and maintains a professional, partnership-oriented tone. No revisions needed; proceed with sending. |
+
+  </Accordion>
+
+  <Accordion title="Example: Multitenancy strategy review">
+    #### Prompt 1
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+    | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | As a senior solutions architect, review and analyze this multitenancy strategy for our new enterprise SaaS product.<br /><br />\<strategy><br />\{\{STRATEGY}}<br />\</strategy><br /><br />Focus on scalability, security, and cost-effectiveness.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    | Assistant<br />\{\{ANALYSIS}} | 1. Scalability:<br />   + Database sharding by tenant reduces contention, supports high growth.<br />   + Microservices allow independent scaling of components.<br />   - Shared app servers could bottleneck under extreme load.<br />   - No mention of auto-scaling or load balancing for app tier.<br /><br />2. Security:<br />   + Tenant data isolation via sharding mitigates data leaks.<br />   + JWT with short expiry and refresh tokens is industry best practice.<br />   - No mention of encryption (at rest, in transit) or key management.<br />   - IAM strategy lacks detail on roles, permissions, or RBAC.<br /><br />3. Cost-effectiveness:<br />   + Shared app servers reduce idle resource costs.<br />   + Serverless functions for infrequent tasks optimize costs.<br />   - Per-tenant DB could increase costs at scale vs. optimized multi-tenant DB.<br />   - No discussion of reserved instances or spot instances for cost saving. |
+
+    #### Prompt 2
+
+    | Role                               | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+    | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                               | Draft a strategy review document for engineering leadership based on this analysis of a multitenancy strategy.<br /><br />\<strategy><br />\{\{STRATEGY}}<br />\</strategy><br /><br />\<analysis><br />\{\{ANALYSIS}}<br />\</analysis><br /><br />Include an executive summary, detailed analysis, and recommendations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+    | Assistant<br />\{\{STRATEGY\_DOC}} | # Multitenancy Strategy Review: SaaS Enterprise Product<br /><br />## Executive Summary<br />The proposed strategy demonstrates a solid foundation in scalability and security principles but has gaps in implementation details. It excels in data isolation and component-level scaling but lacks robust app-tier scaling and advanced security measures. Cost optimizations are present but may falter at high scale. With targeted enhancements, this strategy can effectively support our enterprise SaaS ambitions.<br /><br />## Detailed Analysis<br /><br />### 1. Scalability: B+<br /><br />Strengths:<br />- Database sharding by tenant is excellent. It minimizes query latency, supports high data growth, and facilitates seamless per-tenant scaling.<br />- Microservices architecture allows scaling individual components based on demand, crucial for handling diverse enterprise workloads.<br /><br />Weaknesses:<br />- Shared application servers risk becoming a bottleneck. As tenant count and traffic grow, these could degrade performance across all tenants.<br />- Absence of auto-scaling and load balancing for the app tier is a critical oversight. These are essential for handling traffic spikes without over-provisioning.<br /><br />### 2. Security: B-<br /><br />Strengths:<br />- Sharded databases provide strong tenant data isolation, mitigating risks of data leaks or unauthorized access between tenants.<br />- JWT with short expiry and refresh tokens align with OWASP best practices, reducing token vulnerability windows.<br /><br />Weaknesses:<br />- No mention of data encryption at rest or in transit (TLS 1.3). This is non-negotiable for enterprise data.<br />- Key management strategy is missing. How are encryption keys, JWT secrets, and DB credentials managed and rotated?<br />- IAM lacks depth. We need RBAC with well-defined roles, attribute-based access control (ABAC) for fine-grained permissions, and integration with enterprise identity providers (SAML, OIDC).<br /><br />### 3. Cost-effectiveness: B<br /><br />Strengths:<br />- Shared app servers reduce idle capacity costs, good for steady-state traffic.<br />- Serverless for infrequent tasks (e.g., reporting) is smart; pay only when these resources are used.<br /><br />Weaknesses:<br />- Per-tenant databases may not be cost-effective at scale compared to a well-designed multi-tenant database with robust data partitioning.<br />- No mention of cost-saving measures like reserved instances for predictable workloads or spot instances for fault-tolerant tasks.<br />- Lack of app-tier auto-scaling could lead to over-provisioning, increasing costs.<br /><br />## Recommendations<br /><br />1. **App Tier Resilience**: Implement auto-scaling with Kubernetes or cloud-native services (EKS, GKE). Deploy across availability zones with a CDN for static assets.<br /><br />2. **Security Hardening**:<br />   a. Encrypt data at rest (AES-256) and in transit (TLS 1.3).<br />   b. Use a managed KMS (AWS KMS, GCP KMS) for key management.<br />   c. Enhance IAM with RBAC, ABAC, and SAML/OIDC for enterprise SSO.<br /><br />3. **Cost Optimization**:<br />   a. Evaluate columnar multi-tenant DB (e.g., Snowflake) vs. sharding at scale.<br />   b. Use reserved instances for app servers, spot instances for non-critical workloads.<br />   c. Implement proactive monitoring and right-sizing to avoid overprovisioning.<br /><br />4. **Proof of Concept (PoC)**: Before full implementation, conduct a PoC with a high-scale simulation:<br />   a. Test sharded DB vs. optimized multi-tenant DB for cost and performance.<br />   b. Stress-test app tier with simulated enterprise-level traffic spikes.<br />   c. Conduct third-party security audit, focusing on data isolation and access controls.<br /><br />With these enhancements, our multi-tenancy strategy will be enterprise-grade: scalable, secure, and cost-effective. The PoC will validate our design choices and instill confidence in our enterprise clients. |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | Grade this strategy review document for clarity, actionability, and alignment with enterprise priorities. <br /><br />\<priorities><br />\{\{PRIORITIES}}<br />\</priorities><br /><br />\<strategy\_doc><br />\{\{STRATEGY\_DOC}}<br />\</strategy\_doc>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+    | Assistant | 1. Clarity: A<br />   + Clear structure with Executive Summary, Detailed Analysis, and Recommendations.<br />   + Analysis uses a grading system (B+, B-) for quick grasp of strengths/weaknesses.<br />   + Technical terms (RBAC, ABAC, TLS) are explained or contextualized, aiding non-technical leadership.<br />   + Visual aids (bullet points, indentation) enhance readability.<br /><br />2. Actionability: A-<br />   + Recommendations are specific and technical (e.g., "Implement auto-scaling with Kubernetes").<br />   + PoC plan with clear objectives provides a roadmap.<br />   + Missing: Timelines, resource requirements, or team assignments for each recommendation.<br />   + Consider: Add a "Next Steps" section with immediate actions, roles, and a high-level timeline.<br /><br />3. Enterprise Alignment: A+<br />   + Directly addresses enterprise priorities:<br />     - Scalability: Discusses handling enterprise-level traffic spikes.<br />     - Security: Focuses on data isolation, encryption, and enterprise IAM.<br />     - Cost: Strategies align with enterprise FinOps (reserved instances, right-sizing).<br />   + PoC with "high-scale simulation" and security audit shows commitment to enterprise-grade quality.<br />   + Language resonates with enterprise concerns: "unacceptable risk," "enterprise-grade," "instill confidence."<br /><br />Overall, the document excels in clarity and enterprise alignment. The actionability is strong but could be elevated to A+ with a "Next Steps" section. The technical depth, coupled with clear explanations, makes this highly effective for both technical and non-technical leadership. Great work! |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 7. Meta-Prompting: Let Claude Improve Your Prompts
+
+One of the most powerful techniques is using Claude itself to help refine and improve your prompts. Claude understands its own capabilities and limitations, making it an excellent prompt engineering assistant.
+
+#### How to Use Meta-Prompting
+
+1. **Show Claude your current prompt** along with examples of good and bad outputs
+2. **Ask Claude to critique the prompt** and identify areas for improvement  
+3. **Request specific improvements** like "make this prompt more specific" or "add better examples"
+4. **Iterate on the suggestions** to create increasingly effective prompts
+
+#### Example Meta-Prompting Session
+
+```
+Current prompt: "Analyze the customer feedback and tell me what to improve."
+
+Claude, please critique this prompt and make it better. Here are some examples of outputs I received:
+- [Include actual outputs showing problems]
+
+Make the prompt more specific, add structure, and include examples that would lead to more actionable insights.
+```
+
+Claude can suggest improvements like:
+- Adding role context ("You are a product manager...")
+- Structuring output requirements (using XML tags, bullet points)
+- Including specific examples of good analysis
+- Adding constraints and edge case handling
+
+#### Benefits of Meta-Prompting
+
+- **Leverages Claude's self-knowledge** about what works best
+- **Saves time** compared to manual trial-and-error iteration
+- **Reveals blind spots** you might not have considered
+- **Creates prompt templates** that can be reused across similar tasks
+
+### 8. Long Context Tips
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+Claude's extended context window (200K tokens for Claude 3 models) enables handling complex, data-rich tasks. This guide will help you leverage this power effectively.
+
+#### Essential tips for long context prompts
+
+- **Put longform data at the top**: Place your long documents and inputs (\~20K+ tokens) near the top of your prompt, above your query, instructions, and examples. This can significantly improve Claude's performance across all models.
+
+  <Note>Queries at the end can improve response quality by up to 30% in tests, especially with complex, multi-document inputs.</Note>
+
+- **Structure document content and metadata with XML tags**: When using multiple documents, wrap each document in `<document>` tags with `<document_content>` and `<source>` (and other metadata) subtags for clarity.
+
+  <Accordion title="Example multi-document structure">
+    ```xml
+    <documents>
+      <document index="1">
+        <source>annual_report_2023.pdf</source>
+        <document_content>
+          {{ANNUAL_REPORT}}
+        </document_content>
+      </document>
+      <document index="2">
+        <source>competitor_analysis_q2.xlsx</source>
+        <document_content>
+          {{COMPETITOR_ANALYSIS}}
+        </document_content>
+      </document>
+    </documents>
+
+  Analyze the annual report and competitor analysis. Identify strategic advantages and recommend Q3 focus areas.
+
+  ```
+  </Accordion>
+
+  ```
+
+- **Ground responses in quotes**: For long document tasks, ask Claude to quote relevant parts of the documents first before carrying out its task. This helps Claude cut through the "noise" of the rest of the document's contents.
+
+  <Accordion title="Example quote extraction">
+    ```xml
+    You are an AI physician's assistant. Your task is to help doctors diagnose possible patient illnesses.
+
+    <documents>
+      <document index="1">
+        <source>patient_symptoms.txt</source>
+        <document_content>
+          {{PATIENT_SYMPTOMS}}
+        </document_content>
+      </document>
+      <document index="2">
+        <source>patient_records.txt</source>
+        <document_content>
+          {{PATIENT_RECORDS}}
+        </document_content>
+      </document>
+      <document index="3">
+        <source>patient01_appt_history.txt</source>
+        <document_content>
+          {{PATIENT01_APPOINTMENT_HISTORY}}
+        </document_content>
+      </document>
+    </documents>
+
+  Find quotes from the patient records and appointment history that are relevant to diagnosing the patient's reported symptoms. Place these in <quotes> tags. Then, based on these quotes, list all information that would help the doctor diagnose the patient's symptoms. Place your diagnostic information in <info> tags.
+
+  ```
+  </Accordion>
+  ```
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 8. Extended Thinking Tips
+
+export const TryInConsoleButton = ({userPrompt, systemPrompt, maxTokens, thinkingBudgetTokens, buttonVariant = "primary", children}) => {
+const url = new URL("https://console.anthropic.com/workbench/new");
+if (userPrompt) {
+url.searchParams.set("user", userPrompt);
+}
+if (systemPrompt) {
+url.searchParams.set("system", systemPrompt);
+}
+if (maxTokens) {
+url.searchParams.set("max_tokens", maxTokens);
+}
+if (thinkingBudgetTokens) {
+url.searchParams.set("thinking.budget_tokens", thinkingBudgetTokens);
+}
+return <a href={url.href} className={`btn size-xs ${buttonVariant}`} style={{
+    margin: "-0.25rem -0.5rem"
+  }}>
+{children || "Try in Console"}{" "}
+<Icon icon="arrow-right" color="currentColor" size={14} />
+</a>;
+};
+
+This guide provides advanced strategies and techniques for getting the most out of Claude's extended thinking features. Extended thinking allows Claude to work through complex problems step-by-step, improving performance on difficult tasks.
+
+See [Extended thinking models](/en/docs/about-claude/models/extended-thinking-models) for guidance on deciding when to use extended thinking.
+
+#### Before diving in
+
+This guide presumes that you have already decided to use extended thinking mode and have reviewed our basic steps on [how to get started with extended thinking](/en/docs/about-claude/models/extended-thinking-models#getting-started-with-extended-thinking-models) as well as our [extended thinking implementation guide](/en/docs/build-with-claude/extended-thinking).
+
+##### Technical considerations for extended thinking
+
+- Thinking tokens have a minimum budget of 1024 tokens. We recommend that you start with the minimum thinking budget and incrementally increase to adjust based on your needs and task complexity.
+- For workloads where the optimal thinking budget is above 32K, we recommend that you use [batch processing](/en/docs/build-with-claude/batch-processing) to avoid networking issues. Requests pushing the model to think above 32K tokens causes long running requests that might run up against system timeouts and open connection limits.
+- Extended thinking performs best in English, though final outputs can be in [any language Claude supports](/en/docs/build-with-claude/multilingual-support).
+- If you need thinking below the minimum budget, we recommend using standard mode, with thinking turned off, with traditional chain-of-thought prompting with XML tags (like `<thinking>`). See [chain of thought prompting](/en/docs/build-with-claude/prompt-engineering/chain-of-thought).
+
+#### Prompting techniques for extended thinking
+
+##### Use general instructions first, then troubleshoot with more step-by-step instructions
+
+Claude often performs better with high level instructions to just think deeply about a task rather than step-by-step prescriptive guidance. The model's creativity in approaching problems may exceed a human's ability to prescribe the optimal thinking process.
+
+For example, instead of:
+
+<CodeGroup>
+  ```text User
+  Think through this math problem step by step: 
+  1. First, identify the variables
+  2. Then, set up the equation
+  3. Next, solve for x
+  ...
+  ```
+</CodeGroup>
+
+Consider:
+
+<CodeGroup>
+  ```text User
+  Please think about this math problem thoroughly and in great detail. 
+  Consider multiple approaches and show your complete reasoning.
+  Try different methods if your first approach doesn't work.
+  ```
+
+<CodeBlock
+filename={
+<TryInConsoleButton
+userPrompt={
+`Please think about this math problem thoroughly and in great detail. 
+Consider multiple approaches and show your complete reasoning.
+Try different methods if your first approach doesn't work.`
+}
+thinkingBudgetTokens={16000}
+
+>
+
+    Try in Console
+
+  </TryInConsoleButton>
+}
+  />
+</CodeGroup>
+
+That said, Claude can still effectively follow complex structured execution steps when needed. The model can handle even longer lists with more complex instructions than previous versions. We recommend that you start with more generalized instructions, then read Claude's thinking output and iterate to provide more specific instructions to steer its thinking from there.
+
+##### Multishot prompting with extended thinking
+
+[Multishot prompting](/en/docs/build-with-claude/prompt-engineering/multishot-prompting) works well with extended thinking. When you provide Claude examples of how to think through problems, it will follow similar reasoning patterns within its extended thinking blocks.
+
+You can include few-shot examples in your prompt in extended thinking scenarios by using XML tags like `<thinking>` or `<scratchpad>` to indicate canonical patterns of extended thinking in those examples.
+
+Claude will generalize the pattern to the formal extended thinking process. However, it's possible you'll get better results by giving Claude free rein to think in the way it deems best.
+
+Example:
+
+<CodeGroup>
+  ```text User
+  I'm going to show you how to solve a math problem, then I want you to solve a similar one.
+
+Problem 1: What is 15% of 80?
+
+  <thinking>
+  To find 15% of 80:
+  1. Convert 15% to a decimal: 15% = 0.15
+  2. Multiply: 0.15 × 80 = 12
+  </thinking>
+
+The answer is 12.
+
+Now solve this one:
+Problem 2: What is 35% of 240?
+
+````
+
+<CodeBlock
+  filename={
+<TryInConsoleButton
+  userPrompt={
+    `I'm going to show you how to solve a math problem, then I want you to solve a similar one.
+
+Problem 1: What is 15% of 80?
+
+<thinking>
+To find 15% of 80:
+1. Convert 15% to a decimal: 15% = 0.15
+2. Multiply: 0.15 × 80 = 12
+</thinking>
+
+The answer is 12.
+
+Now solve this one:
+Problem 2: What is 35% of 240?`
+  }
+  thinkingBudgetTokens={16000}
+>
+  Try in Console
+</TryInConsoleButton>
+}
+/>
+</CodeGroup>
+
+##### Maximizing instruction following with extended thinking
+
+Claude shows significantly improved instruction following when extended thinking is enabled. The model typically:
+
+1. Reasons about instructions inside the extended thinking block
+2. Executes those instructions in the response
+
+To maximize instruction following:
+
+* Be clear and specific about what you want
+* For complex instructions, consider breaking them into numbered steps that Claude should work through methodically
+* Allow Claude enough budget to process the instructions fully in its extended thinking
+
+##### Using extended thinking to debug and steer Claude's behavior
+
+You can use Claude's thinking output to debug Claude's logic, although this method is not always perfectly reliable.
+
+To make the best use of this methodology, we recommend the following tips:
+
+* We don't recommend passing Claude's extended thinking back in the user text block, as this doesn't improve performance and may actually degrade results.
+* Prefilling extended thinking is explicitly not allowed, and manually changing the model's output text that follows its thinking block is likely going to degrade results due to model confusion.
+
+When extended thinking is turned off, standard `assistant` response text [prefill](/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response) is still allowed.
+
+<Note>
+Sometimes Claude may repeat its extended thinking in the assistant output text. If you want a clean response, instruct Claude not to repeat its extended thinking and to only output the answer.
+</Note>
+
+##### Making the best of long outputs and longform thinking
+
+For dataset generation use cases, try prompts such as "Please create an extremely detailed table of..." for generating comprehensive datasets.
+
+For use cases such as detailed content generation where you may want to generate longer extended thinking blocks and more detailed responses, try these tips:
+
+* Increase both the maximum extended thinking length AND explicitly ask for longer outputs
+* For very long outputs (20,000+ words), request a detailed outline with word counts down to the paragraph level. Then ask Claude to index its paragraphs to the outline and maintain the specified word counts
+
+<Warning>
+We do not recommend that you push Claude to output more tokens for outputting tokens' sake. Rather, we encourage you to start with a small thinking budget and increase as needed to find the optimal settings for your use case.
+</Warning>
+
+Here are example use cases where Claude excels due to longer extended thinking:
+
+<AccordionGroup>
+<Accordion title="Complex STEM problems">
+  Complex STEM problems require Claude to build mental models, apply specialized knowledge, and work through sequential logical steps—processes that benefit from longer reasoning time.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Write a python script for a bouncing yellow ball within a square,
+        make sure to handle collision detection properly.
+        Make the square slowly rotate.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Write a python script for a bouncing yellow ball within a square,
+make sure to handle collision detection properly.
+Make the square slowly rotate.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This simpler task typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Write a Python script for a bouncing yellow ball within a tesseract,
+        making sure to handle collision detection properly.
+        Make the tesseract slowly rotate.
+        Make sure the ball stays within the tesseract.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Write a Python script for a bouncing yellow ball within a tesseract,
+making sure to handle collision detection properly.
+Make the tesseract slowly rotate.
+Make sure the ball stays within the tesseract.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This complex 4D visualization challenge makes the best use of long extended thinking time as Claude works through the mathematical and programming complexity.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+
+<Accordion title="Constraint optimization problems">
+  Constraint optimization challenges Claude to satisfy multiple competing requirements simultaneously, which is best accomplished when allowing for long extended thinking time so that the model can methodically address each constraint.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Plan a week-long vacation to Japan.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt="Plan a week-long vacation to Japan."
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This open-ended request typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Plan a 7-day trip to Japan with the following constraints:
+        - Budget of $2,500
+        - Must include Tokyo and Kyoto
+        - Need to accommodate a vegetarian diet
+        - Preference for cultural experiences over shopping
+        - Must include one day of hiking
+        - No more than 2 hours of travel between locations per day
+        - Need free time each afternoon for calls back home
+        - Must avoid crowds where possible
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Plan a 7-day trip to Japan with the following constraints:
+- Budget of $2,500
+- Must include Tokyo and Kyoto
+- Need to accommodate a vegetarian diet
+- Preference for cultural experiences over shopping
+- Must include one day of hiking
+- No more than 2 hours of travel between locations per day
+- Need free time each afternoon for calls back home
+- Must avoid crowds where possible`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        With multiple constraints to balance, Claude will naturally perform best when given more space to think through how to satisfy all requirements optimally.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+
+<Accordion title="Thinking frameworks">
+  Structured thinking frameworks give Claude an explicit methodology to follow, which may work best when Claude is given long extended thinking space to follow each step.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Develop a comprehensive strategy for Microsoft
+        entering the personalized medicine market by 2027.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Develop a comprehensive strategy for Microsoft
+entering the personalized medicine market by 2027.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This broad strategic question typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Develop a comprehensive strategy for Microsoft entering
+        the personalized medicine market by 2027.
+
+        Begin with:
+        1. A Blue Ocean Strategy canvas
+        2. Apply Porter's Five Forces to identify competitive pressures
+
+        Next, conduct a scenario planning exercise with four
+        distinct futures based on regulatory and technological variables.
+
+        For each scenario:
+        - Develop strategic responses using the Ansoff Matrix
+
+        Finally, apply the Three Horizons framework to:
+        - Map the transition pathway
+        - Identify potential disruptive innovations at each stage
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Develop a comprehensive strategy for Microsoft entering
+the personalized medicine market by 2027.
+
+Begin with:
+1. A Blue Ocean Strategy canvas
+2. Apply Porter's Five Forces to identify competitive pressures
+
+Next, conduct a scenario planning exercise with four
+distinct futures based on regulatory and technological variables.
+
+For each scenario:
+- Develop strategic responses using the Ansoff Matrix
+
+Finally, apply the Three Horizons framework to:
+- Map the transition pathway
+- Identify potential disruptive innovations at each stage`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        By specifying multiple analytical frameworks that must be applied sequentially, thinking time naturally increases as Claude works through each framework methodically.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+</AccordionGroup>
+
+##### Have Claude reflect on and check its work for improved consistency and error handling
+
+You can use simple natural language prompting to improve consistency and reduce errors:
+
+1. Ask Claude to verify its work with a simple test before declaring a task complete
+2. Instruct the model to analyze whether its previous step achieved the expected result
+3. For coding tasks, ask Claude to run through test cases in its extended thinking
+
+Example:
+
+<CodeGroup>
+```text User
+Write a function to calculate the factorial of a number.
+Before you finish, please verify your solution with test cases for:
+- n=0
+- n=1
+- n=5
+- n=10
+And fix any issues you find.
+````
+
+<CodeBlock
+filename={
+<TryInConsoleButton
+userPrompt={
+`Write a function to calculate the factorial of a number.
+Before you finish, please verify your solution with test cases for:
+
+- n=0
+- n=1
+- n=5
+- n=10
+  And fix any issues you find.`
+  }
+  thinkingBudgetTokens={16000}
+  >
+      Try in Console
+    </TryInConsoleButton>
+  }
+    />
+  </CodeGroup>
+
+#### Next steps
+
+<CardGroup>
+  <Card title="Extended thinking cookbook" icon="book" href="https://github.com/anthropics/anthropic-cookbook/tree/main/extended_thinking">
+    Explore practical examples of extended thinking in our cookbook.
+  </Card>
+
+  <Card title="Extended thinking guide" icon="code" href="/en/docs/build-with-claude/extended-thinking">
+    See complete technical documentation for implementing extended thinking.
+  </Card>
+</CardGroup>
+
+### Claude 4 Best Practices
+
+Claude 4 models (Opus 4 and Sonnet 4) have been trained for more precise instruction following than previous generations.
+
+### General Principles
+
+#### Be explicit with your instructions
+
+Claude 4 models respond well to clear, explicit instructions. Being specific about your desired output can help enhance results. Customers who desire the "above and beyond" behavior from previous Claude models might need to more explicitly request these behaviors with Claude 4.
+
+<Accordion title="Example: Creating an analytics dashboard">
+  **Less effective:**
+
+```text
+Create an analytics dashboard
+```
+
+**More effective:**
+
+```text
+Create an analytics dashboard. Include as many relevant features and interactions as possible. Go beyond the basics to create a fully-featured implementation.
+```
+
+</Accordion>
+
+#### Add context to improve performance
+
+Providing context or motivation behind your instructions, such as explaining to Claude why such behavior is important, can help Claude 4 better understand your goals and deliver more targeted responses.
+
+<Accordion title="Example: Formatting preferences">
+  **Less effective:**
+
+```text
+NEVER use ellipses
+```
+
+**More effective:**
+
+```text
+Your response will be read aloud by a text-to-speech engine, so never use ellipses since the text-to-speech engine will not know how to pronounce them.
+```
+
+</Accordion>
+
+Claude is smart enough to generalize from the explanation.
+
+#### Be vigilant with examples & details
+
+Claude 4 models pay attention to details and examples as part of instruction following. Ensure that your examples align with the behaviors you want to encourage and minimize behaviors you want to avoid.
+
+### Guidance for Specific Situations
+
+#### Control the format of responses
+
+There are a few ways that we have found to be particularly effective in steering output formatting in Claude 4 models:
+
+1. **Tell Claude what to do instead of what not to do**
+
+   - Instead of: "Do not use markdown in your response"
+   - Try: "Your response should be composed of smoothly flowing prose paragraphs."
+
+2. **Use XML format indicators**
+
+   - Try: "Write the prose sections of your response in \<smoothly_flowing_prose_paragraphs> tags."
+
+3. **Match your prompt style to the desired output**
+
+   The formatting style used in your prompt may influence Claude's response style. If you are still experiencing steerability issues with output formatting, we recommend as best as you can matching your prompt style to your desired output style. For example, removing markdown from your prompt can reduce the volume of markdown in the output.
+
+#### Leverage thinking & interleaved thinking capabilities
+
+Claude 4 offers thinking capabilities that can be especially helpful for tasks involving reflection after tool use or complex multi-step reasoning. You can guide its initial or interleaved thinking for better results.
+
+```text Example prompt
+After receiving tool results, carefully reflect on their quality and determine optimal next steps before proceeding. Use your thinking to plan and iterate based on this new information, and then take the best next action.
+```
+
+<Info>
+  For more information on thinking capabilities, see [Extended thinking](/en/docs/build-with-claude/extended-thinking).
+</Info>
+
+#### Optimize parallel tool calling
+
+Claude 4 models excel at parallel tool execution. They have a high success rate in using parallel tool calling without any prompting to do so, but some minor prompting can boost this behavior to \~100% parallel tool use success rate. We have found this prompt to be most effective:
+
+```text Sample prompt for agents
+For maximum efficiency, whenever you need to perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially.
+```
+
+#### Reduce file creation in agentic coding
+
+Claude 4 models may sometimes create new files for testing and iteration purposes, particularly when working with code. This approach allows Claude to use files, especially python scripts, as a 'temporary scratchpad' before saving its final output. Using temporary files can improve outcomes particularly for agentic coding use cases.
+
+If you'd prefer to minimize net new file creation, you can instruct Claude to clean up after itself:
+
+```text Sample prompt
+If you create any temporary new files, scripts, or helper files for iteration, clean up these files by removing them at the end of the task.
+```
+
+#### Enhance visual and frontend code generation
+
+For frontend code generation, you can steer Claude 4 models to create complex, detailed, and interactive designs by providing explicit encouragement:
+
+```text Sample prompt
+Don't hold back. Give it your all.
+```
+
+You can also improve Claude's frontend performance in specific areas by providing additional modifiers and details on what to focus on:
+
+- "Include as many relevant features and interactions as possible"
+- "Add thoughtful details like hover states, transitions, and micro-interactions"
+- "Create an impressive demonstration showcasing web development capabilities"
+- "Apply design principles: hierarchy, contrast, balance, and movement"
+
+### Migration Considerations
+
+When migrating from Sonnet 3.7 to Claude 4:
+
+1. **Be specific about desired behavior**: Consider describing exactly what you'd like to see in the output.
+
+2. **Frame your instructions with modifiers**: Adding modifiers that encourage Claude to increase the quality and detail of its output can help better shape Claude's performance. For example, instead of "Create an analytics dashboard", use "Create an analytics dashboard. Include as many relevant features and interactions as possible. Go beyond the basics to create a fully-featured implementation."
+
+3. **Request specific features explicitly**: Animations and interactive elements should be requested explicitly when desired.
+
+#### Model Personalities & Distillation Strategy
+
+Different LLMs have distinct "personalities" and capabilities. Understanding these can help you optimize your prompts:
+
+**Claude Characteristics:**
+- More conversational and human-like in responses
+- Strong at following complex instructions and reasoning
+- Excels at ethical reasoning and nuanced analysis
+- Generally requires less explicit steering than other models
+
+**Cross-Model Considerations:**
+- **Llama models** might need more explicit steering and structure
+- **GPT models** may have different formatting preferences
+- **Smaller models** often benefit from more specific instructions
+
+**Distillation Strategy:**
+1. **Develop with larger models:** Use Claude 4 or other capable models for complex meta-prompting and refinement
+2. **Test across models:** Validate prompts work across your target model types
+3. **Distill for production:** Adapt optimized prompts for smaller, faster, or cheaper models
+4. **Maintain quality:** Use evaluation suites to ensure performance doesn't degrade
+
+This approach optimizes for both quality (from larger models) and cost/latency (with smaller models).
+
+## Evaluation: Your Crown Jewels
+
+While prompts are important, your evaluation suite (the set of test cases to measure prompt quality and performance) is often your most valuable intellectual property. Leading AI startups consider evals their secret weapon.
+
+### Why Evaluations Matter
+
+- **Objective measurement:** Know definitively whether a prompt change improves or degrades performance  
+- **Iterative improvement:** Essential for knowing why a prompt works and for iterating effectively
+- **Quality assurance:** Prevent regressions when updating prompts or switching models
+- **Benchmarking:** Compare performance across different models or prompt variations
+
+### Building Effective Evaluation Suites
+
+1. **Diverse test cases:** Cover edge cases, typical scenarios, and failure modes
+2. **Clear success criteria:** Define what "good" output looks like for each test case
+3. **Automated scoring:** Where possible, use automated metrics (accuracy, format compliance, etc.)
+4. **Human evaluation:** Include human judgment for nuanced tasks like tone, creativity, or ethical reasoning
+5. **Representative data:** Use real-world data that matches your production use cases
+
+### Evaluation-Driven Development
+
+```
+1. Define success metrics for your task
+2. Create comprehensive test cases  
+3. Baseline current prompt performance
+4. Iterate on prompts using meta-prompting and other techniques
+5. Run evaluations to measure improvement
+6. Deploy only changes that improve eval scores
+```
+
+**Pro tip:** Start building your evaluation suite early, even before perfecting your prompts. The insights from systematic evaluation often reveal prompt improvement opportunities you wouldn't have discovered otherwise.
+
+### Claude Code Workflows
+
+#### Give Claude more tools
+
+Claude has access to your shell environment, where you can build up sets of convenience scripts and functions for it just like you would for yourself. It can also leverage more complex tools through MCP and REST APIs.
+
+#### a. Use Claude with bash tools
+
+Claude Code inherits your bash environment, giving it access to all your tools. While Claude knows common utilities like unix tools and gh, it won't know about your custom bash tools without instructions:
+
+- Tell Claude the tool name with usage examples
+- Tell Claude to run --help to see tool documentation
+- Document frequently used tools in CLAUDE.md
+
+### Recommended Workflows
+
+#### Recommended Workflows
+
+**Research, Plan, Implement**
+
+1. Ask Claude to read relevant files, images, or URLs, providing either general pointers ("read the file that handles logging") or specific filenames ("read logging.py"), but explicitly tell it not to write any code just yet.
+2. This is the part of the workflow where you should consider strong use of subagents, especially for complex problems. Telling Claude to use subagents to verify details or investigate particular questions it might have, especially early on in a conversation or task, tends to preserve context availability without much downside in terms of lost efficiency.
+3. Ask Claude to make a plan for how to approach a specific problem. We recommend using the word "think" to trigger extended thinking mode, which gives Claude additional computation time to evaluate alternatives more thoroughly. These specific phrases are mapped directly to increasing levels of thinking budget in the system: "think" < "think hard" < "think harder" < "ultrathink." Each level allocates progressively more thinking budget for Claude to use.
+4. If the results of this step seem reasonable, you can have Claude create a document or a GitHub issue with its plan so that you can reset to this spot if the implementation (step 3) isn't what you want.
+5. Ask Claude to implement its solution in code. This is also a good place to ask it to explicitly verify the reasonableness of its solution as it implements pieces of the solution.
+6. Ask Claude to commit the result and create a pull request. If relevant, this is also a good time to have Claude update any READMEs or changelogs with an explanation of what it just did.
+
+Steps #1-#2 are crucial—without them, Claude tends to jump straight to coding a solution. While sometimes that's what you want, asking Claude to research and plan first significantly improves performance for problems requiring deeper thinking upfront.
+
+**Write tests, commit; code, iterate, commit**
+
+This is an Anthropic-favorite workflow for changes that are easily verifiable with unit, integration, or end-to-end tests. Test-driven development (TDD) becomes even more powerful with agentic coding:
+
+1. Ask Claude to write tests based on expected input/output pairs. Be explicit about the fact that you're doing test-driven development so that it avoids creating mock implementations, even for functionality that doesn't exist yet in the codebase.
+2. Tell Claude to run the tests and confirm they fail. Explicitly telling it not to write any implementation code at this stage is often helpful.
+3. Ask Claude to commit the tests when you're satisfied with them.
+4. Ask Claude to write code that passes the tests, instructing it not to modify the tests. Tell Claude to keep going until all tests pass. It will usually take a few iterations for Claude to write code, run the tests, adjust the code, and run the tests again.
+5. At this stage, it can help to ask it to verify with independent subagents that the implementation isn't overfitting to the tests
+6. Ask Claude to commit the code once you're satisfied with the changes.
+
+Claude performs best when it has a clear target to iterate against—a visual mock, a test case, or another kind of output. By providing expected outputs like tests, Claude can make changes, evaluate results, and incrementally improve until it succeeds.
+
+**Write code, screenshot result, iterate**
+
+Similar to the testing workflow, you can provide Claude with visual targets:
+
+1. Give Claude a way to take browser screenshots (e.g., with the Puppeteer MCP server, an iOS simulator MCP server, or manually copy / paste screenshots into Claude).
+2. Give Claude a visual mock by copying / pasting or drag-dropping an image, or giving Claude the image file path.
+3. Ask Claude to implement the design in code, take screenshots of the result, and iterate until its result matches the mock.
+4. Ask Claude to commit when you're satisfied.
+
+Like humans, Claude's outputs tend to improve significantly with iteration. While the first version might be good, after 2-3 iterations it will typically look much better. Give Claude the tools to see its outputs for best results.
+
+**Use Claude to interact with git**
+
+Claude can effectively handle many git operations. Many Anthropic engineers use Claude for 90%+ of our git interactions:
+
+- Searching git history to answer questions like "What changes made it into v1.2.3?", "Who owns this particular feature?", or "Why was this API designed this way?" It helps to explicitly prompt Claude to look through git history to answer queries like these.
+- Writing commit messages. Claude will look at your changes and recent history automatically to compose a message taking all the relevant context into account
+- Handling complex git operations like reverting files, resolving rebase conflicts, and comparing and grafting patches
+
+**Use Claude to interact with GitHub**
+
+Claude Code can manage many GitHub interactions:
+
+- Creating pull requests: Claude understands the shorthand "pr" and will generate appropriate commit messages based on the diff and surrounding context.
+- Implementing one-shot resolutions for simple code review comments: just tell it to fix comments on your PR (optionally, give it more specific instructions) and push back to the PR branch when it's done.
+- Fixing failing builds or linter warnings
+- Categorizing and triaging open issues by asking Claude to loop over open GitHub issues
+
+This eliminates the need to remember gh command line syntax while automating routine tasks.
+
+**Use Claude to work with Jupyter notebooks**
+
+Researchers and data scientists at Anthropic use Claude Code to read and write Jupyter notebooks. Claude can interpret outputs, including images, providing a fast way to explore and interact with data. There are no required prompts or workflows, but a workflow we recommend is to have Claude Code and a .ipynb file open side-by-side in VS Code.
+
+You can also ask Claude to clean up or make aesthetic improvements to your Jupyter notebook before you show it to colleagues. Specifically telling it to make the notebook or its data visualizations "aesthetically pleasing" tends to help remind it that it's optimizing for a human viewing experience.
+
+#### Optimize Your Workflow
+
+The suggestions below apply across all workflows:
+
+**Be specific in your instructions**
+
+Claude Code's success rate improves significantly with more specific instructions, especially on first attempts. Giving clear directions upfront reduces the need for course corrections later.
+
+For example:
+
+| Poor                                             | Good                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| add tests for foo.py                             | write a new test case for foo.py, covering the edge case where the user is logged out. avoid mocks                                                                                                                                                                                                                                                                                                                                                      |
+| why does ExecutionFactory have such a weird api? | look through ExecutionFactory's git history and summarize how its api came to be                                                                                                                                                                                                                                                                                                                                                                        |
+| add a calendar widget                            | look at how existing widgets are implemented on the home page to understand the patterns and specifically how code and interfaces are separated out. HotDogWidget.php is a good example to start with. then, follow the pattern to implement a new calendar widget that lets the user select a month and paginate forwards/backwards to pick a year. Build from scratch without libraries other than the ones already used in the rest of the codebase. |
+
+Claude can infer intent, but it can't read minds. Specificity leads to better alignment with expectations.
+
+**Give Claude images**
+
+Claude excels with images and diagrams through several methods:
+
+- Paste screenshots (pro tip: hit cmd+ctrl+shift+4 in macOS to screenshot to clipboard and ctrl+v to paste. Note that this is not cmd+v like you would usually use to paste on mac and does not work remotely.)
+- Drag and drop images directly into the prompt input
+- Provide file paths for images
+
+This is particularly useful when working with design mocks as reference points for UI development, and visual charts for analysis and debugging. If you are not adding visuals to context, it can still be helpful to be clear with Claude about how important it is for the result to be visually appealing.
+
+**Mention files you want Claude to look at or work on**
+
+Use tab-completion to quickly reference files or folders anywhere in your repository, helping Claude find or update the right resources.
+
+**Give Claude URLs**
+
+Paste specific URLs alongside your prompts for Claude to fetch and read. To avoid permission prompts for the same domains (e.g., docs.foo.com), use /allowed-tools to add domains to your allowlist.
+
+**Course correct early and often**
+
+While auto-accept mode (shift+tab to toggle) lets Claude work autonomously, you'll typically get better results by being an active collaborator and guiding Claude's approach. You can get the best results by thoroughly explaining the task to Claude at the beginning, but you can also course correct Claude at any time.
+
+These four tools help with course correction:
+
+1. Ask Claude to make a plan before coding. Explicitly tell it not to code until you've confirmed its plan looks good.
+2. Press Escape to interrupt Claude during any phase (thinking, tool calls, file edits), preserving context so you can redirect or expand instructions.
+3. Double-tap Escape to jump back in history, edit a previous prompt, and explore a different direction. You can edit the prompt and repeat until you get the result you're looking for.
+4. Ask Claude to undo changes, often in conjunction with option #2 to take a different approach.
+
+Though Claude Code occasionally solves problems perfectly on the first attempt, using these correction tools generally produces better solutions faster.
+
+**Use /clear to keep context focused**
+
+During long sessions, Claude's context window can fill with irrelevant conversation, file contents, and commands. This can reduce performance and sometimes distract Claude. Use the /clear command frequently between tasks to reset the context window.
+
+**Use checklists and scratchpads for complex workflows**
+
+For large tasks with multiple steps or requiring exhaustive solutions—like code migrations, fixing numerous lint errors, or running complex build scripts—improve performance by having Claude use a Markdown file (or even a GitHub issue!) as a checklist and working scratchpad:
+
+For example, to fix a large number of lint issues, you can do the following:
+
+1. Tell Claude to run the lint command and write all resulting errors (with filenames and line numbers) to a Markdown checklist
+2. Instruct Claude to address each issue one by one, fixing and verifying before checking it off and moving to the next
+
+**Pass data into Claude**
+
+Several methods exist for providing data to Claude:
+
+- Copy and paste directly into your prompt (most common approach)
+- Pipe into Claude Code (e.g., cat foo.txt | claude), particularly useful for logs, CSVs, and large data
+- Tell Claude to pull data via bash commands, MCP tools, or custom slash commands
+- Ask Claude to read files or fetch URLs (works for images too)
+
+Most sessions involve a combination of these approaches. For example, you can pipe in a log file, then tell Claude to use a tool to pull in additional context to debug the logs.

--- a/.claude/commands/agents/AGENT-improve-command.md
+++ b/.claude/commands/agents/AGENT-improve-command.md
@@ -1,0 +1,1505 @@
+# Improve Claude Code Command
+
+<task>
+You can find the existing command at $ARGUMENTS. I want to improve it so it better follows the best-practices for writing prompts and Claude Code commands. Make the changes to the file in-place.
+</task>
+
+## Command Improvement Guide
+
+### What You'll Improve
+
+Claude Code commands are stored prompt templates in Markdown files within the `.claude/commands` folder. You'll be enhancing an existing command to follow current best practices for prompt engineering and command structure.
+
+**Your goal:** Apply the advanced prompting techniques below to make the existing command more effective, reliable, and aligned with state-of-the-art practices.
+
+### Basic Command Structure
+
+```md
+Please analyze and fix the GitHub issue: $ARGUMENTS.
+
+Follow these steps:
+
+1. Use `gh issue view` to get the issue details
+2. Understand the problem described in the issue
+3. Search the codebase for relevant files
+4. Implement the necessary changes to fix the issue
+5. Write and run tests to verify the fix
+6. Ensure code passes linting and type checking
+7. Create a descriptive commit message
+8. Push and create a PR
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.
+```
+
+### Command Locations
+
+Commands are found in:
+- `.claude/commands/` folder for project-specific commands
+- `~/.claude/commands` folder for personal commands available in all sessions
+
+<resources>
+When improving the command, refer to these resources to determine the best way to format, structure, and word the prompt:
+
+- [Prompt Library](https://docs.anthropic.com/en/resources/prompt-library/library)
+- [Claude Code Tutorials](https://docs.anthropic.com/en/docs/claude-code/tutorials)
+</resources>
+
+## Essential Background Information
+
+### Claude Code Overview
+
+Claude Code is an agentic coding assistant that automatically pulls context into prompts. This context gathering consumes time and tokens, but you can optimize it through environment tuning.
+
+#### Create CLAUDE.md files
+
+CLAUDE.md is a special file that Claude automatically pulls into context when starting a conversation. This makes it an ideal place for documenting:
+
+- Common bash commands
+- Core files and utility functions
+- Code style guidelines
+- Testing instructions
+- Repository etiquette (e.g., branch naming, merge vs. rebase, etc.)
+- Developer environment setup (e.g., pyenv use, which compilers work)
+- Any unexpected behaviors or warnings particular to the project
+- Other information you want Claude to remember
+
+There's no required format for CLAUDE.md files. We recommend keeping them concise and human-readable. For example:
+
+```
+# Bash commands
+- npm run build: Build the project
+- npm run typecheck: Run the typechecker
+
+# Code style
+- Use ES modules (import/export) syntax, not CommonJS (require)
+- Destructure imports when possible (eg. import { foo } from 'bar')
+
+# Workflow
+- Be sure to typecheck when you're done making a series of code changes
+- Prefer running single tests, and not the whole test suite, for performance
+```
+
+You can place CLAUDE.md files in several locations:
+
+- The root of your repo, or wherever you run claude from (the most common usage). Name it CLAUDE.md and check it into git so that you can share it across sessions and with your team (recommended), or name it CLAUDE.local.md and .gitignore it
+- Any parent of the directory where you run claude. This is most useful for monorepos, where you might run claude from root/foo, and have CLAUDE.md files in both root/CLAUDE.md and root/foo/CLAUDE.md. Both of these will be pulled into context automatically
+- Any child of the directory where you run claude. This is the inverse of the above, and in this case, Claude will pull in CLAUDE.md files on demand when you work with files in child directories
+- Your home folder (~/.claude/CLAUDE.md), which applies it to all your claude sessions
+
+When you run the /init command, Claude will automatically generate a CLAUDE.md for you.
+
+#### Tune your CLAUDE.md files
+
+Your CLAUDE.md files become part of Claude's prompts, so they should be refined like any frequently used prompt. A common mistake is adding extensive content without iterating on its effectiveness. Take time to experiment and determine what produces the best instruction following from the model.
+
+You can add content to your CLAUDE.md manually or press the # key to give Claude an instruction that it will automatically incorporate into the relevant CLAUDE.md. Many engineers use # frequently to document commands, files, and style guidelines while coding, then include CLAUDE.md changes in commits so team members benefit as well.
+
+At Anthropic, we occasionally run CLAUDE.md files through the prompt improver and often tune instructions (e.g. adding emphasis with "IMPORTANT" or "YOU MUST") to improve adherence.
+
+## Advanced Prompting Reference
+
+<note>
+The following comprehensive prompting guide will help you improve existing commands. Apply these principles when refining the command prompt.
+</note>
+
+### 1. Be Direct
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When interacting with Claude, think of it as a brilliant but very new employee (with amnesia) who needs explicit instructions. Like any new employee, Claude does not have context on your norms, styles, guidelines, or preferred ways of working.
+The more precisely you explain what you want, the better Claude's response will be.
+
+<Tip>**The golden rule of clear prompting**<br />Show your prompt to a colleague, ideally someone who has minimal context on the task, and ask them to follow the instructions. If they're confused, Claude will likely be too.</Tip>
+
+#### How to be clear, contextual, and specific
+
+- **Give Claude contextual information:** Just like you might be able to better perform on a task if you knew more context, Claude will perform better if it has more contextual information. Some examples of contextual information:
+  - What the task results will be used for
+  - What audience the output is meant for
+  - What workflow the task is a part of, and where this task belongs in that workflow
+  - The end goal of the task, or what a successful task completion looks like
+- **Be specific about what you want Claude to do:** For example, if you want Claude to output only code and nothing else, say so.
+- **Provide instructions as sequential steps:** Use numbered lists or bullet points to better ensure that Claude carries out the task the exact way you want it to.
+
+#### The "Manager" Approach: Hyper-Detailed Prompts
+
+For complex agent systems, treat Claude like a new employee who needs comprehensive training. Leading AI startups like Parahelp use prompts that are 6+ pages long, meticulously outlining:
+
+- **Detailed role definition:** Exactly who Claude is and what expertise it should demonstrate
+- **Comprehensive task breakdown:** Every step, decision point, and contingency 
+- **Explicit constraints and guidelines:** What Claude should and shouldn't do
+- **Output format specifications:** Exact structure, formatting, and required elements
+- **Error handling procedures:** How to respond when information is missing or unclear
+
+This approach significantly improves reliability for complex agent workflows, though it requires more upfront investment in prompt development.
+
+#### Implement an "Escape Hatch"
+
+Always instruct Claude to explicitly state when it doesn't know something or lacks sufficient information, rather than hallucinating or making assumptions:
+
+```
+If you do not have enough information to make a determination, say "I don't know" and ask for clarification. Never guess or make up information.
+```
+
+This reduces incorrect outputs and improves trustworthiness in agent systems.
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Anonymizing customer feedback">
+    Notice that Claude still makes mistakes in the unclear prompting example, such as leaving in a customer's name.
+
+    | Role                          | Unclear Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Clear Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                          | Please remove all personally identifiable information from these customer feedback messages: \{\{FEEDBACK\_DATA}}                                                                                                                                                                                                                                                                                                                                                     | Your task is to anonymize customer feedback for our quarterly review.<br /><br />Instructions:<br />1. Replace all customer names with "CUSTOMER\_\[ID]" (e.g., "Jane Doe" → "CUSTOMER\_001").<br />2. Replace email addresses with "EMAIL\_\[ID]@example.com".<br />3. Redact phone numbers as "PHONE\_\[ID]".<br />4. If a message mentions a specific product (e.g., "AcmeCloud"), leave it intact.<br />5. If no PII is found, copy the message verbatim.<br />6. Output only the processed messages, separated by "---".<br /><br />Data to process: \{\{FEEDBACK\_DATA}} |
+    | Assistant (Claude's response) | Here are the anonymized customer feedback messages:<br />1. I've been using your software for years, and it's been great. But lately, AcmeCloud has been crashing a lot. Fix it!<br />2. XXX, your customer support rep, was incredibly helpful. He guided me through the whole process. My email is XXX if you want to send a survey.<br />3. I'm John Smith, and I'm not happy. I've been on hold for 2 hours trying to reach someone at XXX. This is unacceptable! | CUSTOMER\_001: I've been using your software for years, and it's been great. But lately, AcmeCloud has been crashing a lot. Fix it!<br />---<br />CUSTOMER\_002: CUSTOMER\_SERVICE\_001, your customer support rep, was incredibly helpful. He guided me through the whole process. My email is [EMAIL\_002@example.com](mailto:EMAIL_002@example.com) if you want to send a survey.<br />---<br />CUSTOMER\_003: I'm CUSTOMER\_003, and I'm not happy. I've been on hold for 2 hours trying to reach someone at PHONE\_001. This is unacceptable!                             |
+
+  </Accordion>
+
+  <Accordion title="Example: Crafting a marketing email campaign">
+    Notice that Claude makes up details to fill in the gaps where it lacks context with the vague prompt.
+
+    | Role                          | Vague Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Specific Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Write a marketing email for our new AcmeCloud features.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Your task is to craft a targeted marketing email for our Q3 AcmeCloud feature release.<br /><br />Instructions:<br />1. Write for this target audience: Mid-size tech companies (100-500 employees) upgrading from on-prem to cloud.<br />2. Highlight 3 key new features: advanced data encryption, cross-platform sync, and real-time collaboration.<br />3. Tone: Professional yet approachable. Emphasize security, efficiency, and teamwork.<br />4. Include a clear CTA: Free 30-day trial with priority onboarding.<br />5. Subject line: Under 50 chars, mention "security" and "collaboration".<br />6. Personalization: Use \{\{COMPANY\_NAME}} and \{\{CONTACT\_NAME}} variables.<br /><br />Structure:<br />1. Subject line<br />2. Email body (150-200 words)<br />3. CTA button text                                                                                                                                                                                                                                                                                                                                                        |
+    | Assistant (Claude's response) | Here's a draft marketing email for our new features:<br /><br />Subject: Boost Your Business with AcmeCloud's Latest Features<br /><br />Dear Valued Customer,<br /><br />We're excited to introduce three powerful features to AcmeCloud that will revolutionize your workflow:<br /><br />1. Real-Time Collaboration: Work on documents simultaneously with your team. No more version control issues!<br />2. AI-Powered Insights: Make data-driven decisions with AI that analyzes trends and automates tasks.<br />3. Advanced Security Suite: End-to-end encryption, multi-factor auth, and threat detection keep your data safe.<br /><br />Limited Offer: Upgrade now for a 20% first-year discount. Plus, refer a friend for an extra 10% off!<br /><br />Best,<br />The AcmeCloud Team | Subject line: AcmeCloud: Enterprise security meets real-time teamwork<br /><br />Email body:<br />Dear \{\{CONTACT\_NAME}},<br /><br />At \{\{COMPANY\_NAME}}, you're scaling fast and eyeing the cloud. But with growth comes the challenge of keeping data secure while fostering collaboration. That's where AcmeCloud's Q3 release comes in, tailor-made for tech innovators like you.<br /><br />1. Fort Knox for Your Files: Military-grade encryption now safeguards your data, both in motion and at rest. Your intellectual property stays yours, period.<br />2. Sync Without Borders: Windows, Mac, or Linux—AcmeCloud speaks all languages. Unified version control means no more "final\_v2\_REALLY\_FINAL.doc".<br />3. Collaborate at Light Speed: Ditch the attachment ping-pong. Now your devs, designers, and data scientists co-create in real-time, slashing time-to-market.<br /><br />Don't just take our word for it. Experience the AcmeCloud difference with our 30-day trial. And because we know time is your most precious asset, we're throwing in priority onboarding.<br /><br />Elevate Your Team Now - Free 30-Day Trial |
+
+  </Accordion>
+
+  <Accordion title="Example: Incident response">
+    Notice that Claude outputs superfluous text and different formatting with the vague prompt.
+
+    | Role                          | Vague Prompt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Detailed Prompt                                                                                                                                                                                                                                                                                                         |
+    | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Analyze this AcmeCloud outage report and summarize the key points.<br /><br />\{\{REPORT}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Analyze this AcmeCloud outage report. Skip the preamble. Keep your response terse and write only the bare bones necessary information. List only:<br />1) Cause<br />2) Duration<br />3) Impacted services<br />4) Number of affected users<br />5) Estimated revenue loss. <br /><br />Here's the report: \{\{REPORT}} |
+    | Assistant (Claude's response) | Here's a summary of the key points from the AcmeCloud outage report:<br /><br />On May 15th, a misconfigured load balancer update caused significant traffic routing issues, resulting in a service outage from 09:15 to 13:52 UTC. The 4-hour 37-minute disruption impacted our core file syncing service and admin dashboard, rendering them inaccessible. Additionally, the mobile app experienced partial functionality loss. Approximately 68% of our user base, totaling 1.3 million users, were affected. Based on our Service Level Agreements (SLAs) and average revenue per user, we estimate a financial impact of \$420,000 in service credits and potential customer churn. | 1) Cause: Misconfigured load balancer update<br />2) Duration: 4h 37m (09:15-13:52 UTC, May 15)<br />3) Impacted: Core sync, admin dashboard (down); mobile app (partial)<br />4) Affected users: 1.3M (68% of base)<br />5) Est. revenue loss: \$420,000                                                               |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 2. Use Examples (Multishot Prompting)
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+Examples are your secret weapon shortcut for getting Claude to generate exactly what you need. By providing a few well-crafted examples in your prompt, you can dramatically improve the accuracy, consistency, and quality of Claude's outputs.
+This technique, known as few-shot or multishot prompting, is particularly effective for tasks that require structured outputs or adherence to specific formats.
+
+<Tip>**Power up your prompts**: Include 3-5 diverse, relevant examples to show Claude exactly what you want. More examples = better performance, especially for complex tasks.</Tip>
+
+#### Why use examples?
+
+- **Accuracy**: Examples reduce misinterpretation of instructions.
+- **Consistency**: Examples enforce uniform structure and style.
+- **Performance**: Well-chosen examples boost Claude's ability to handle complex tasks.
+
+#### Crafting effective examples
+
+For maximum effectiveness, make sure that your examples are:
+
+- **Relevant**: Your examples mirror your actual use case.
+- **Diverse**: Your examples cover edge cases and potential challenges, and vary enough that Claude doesn't inadvertently pick up on unintended patterns.
+- **Clear**: Your examples are wrapped in `<example>` tags (if multiple, nested within `<examples>` tags) for structure.
+
+<Tip>Ask Claude to evaluate your examples for relevance, diversity, or clarity. Or have Claude generate more examples based on your initial set.</Tip>
+
+<Accordion title="Example: Analyzing customer feedback">
+  Notice that in the "no examples" version, Claude does not list multiple options for each category, despite its written analysis indicating that there are multiple categories for certain feedback. It also includes a long explanation when we may not want it to.
+
+| Role                          | No Examples                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | With Examples                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User                          | Analyze this customer feedback and categorize the issues. Use these categories: UI/UX, Performance, Feature Request, Integration, Pricing, and Other. Also rate the sentiment (Positive/Neutral/Negative) and priority (High/Medium/Low).<br /><br />Here is the feedback: \{\{FEEDBACK}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Our CS team is overwhelmed with unstructured feedback. Your task is to analyze feedback and categorize issues for our product and engineering teams. Use these categories: UI/UX, Performance, Feature Request, Integration, Pricing, and Other. Also rate the sentiment (Positive/Neutral/Negative) and priority (High/Medium/Low). Here is an example:<br /><br />\<example><br />Input: The new dashboard is a mess! It takes forever to load, and I can't find the export button. Fix this ASAP!<br />Category: UI/UX, Performance<br />Sentiment: Negative<br />Priority: High\</example><br /><br />Now, analyze this feedback: \{\{FEEDBACK}}                                                                                                                                                                                                                                                                                                                                                                                               |
+| Assistant (Claude's response) | Here's the analysis of the customer feedback:<br /><br />Issue: UI/UX<br />Sentiment: Negative<br />Priority: High<br />The customer is frustrated with the new dashboard design, which they find cluttered and slow to load. They specifically call out the missing "export" button, which is likely a critical feature. This issue needs to be addressed as a high priority.<br /><br />Issue: Integration<br />Sentiment: Positive<br />Priority: Medium<br />The customer is pleased with the existing Salesforce integration but would like to see support for Hubspot as well. This is a feature request that could be considered for a future product update.<br /><br />Issue: Pricing<br />Sentiment: Negative<br />Priority: High<br />The customer finds the pricing to be unreasonable, especially for the basic features. They are threatening to switch to a competitor, so this is a high-priority issue that needs to be reviewed.<br /><br />Issue: Performance<br />Sentiment Negative<br />Priority: High<br />The customer is experiencing critical issues with the mobile app, where large file uploads consistently result in crashes. This is a significant problem that impacts the customer's ability to use the product effectively and should be addressed as a high priority.<br /><br />Issue: UI/UX<br />Sentiment: Positive<br />Priority: Low<br />The customer is overall satisfied with the product, specifically calling out the intuitive UI and excellent customer support. This is a positive piece of feedback that does not require any immediate action. | Here's the analysis of the customer feedback:<br /><br />1. The new dashboard is a mess! It takes forever to load, and I can't find the export button. Fix this ASAP!<br />Category: UI/UX, Performance<br />Sentiment: Negative<br />Priority: High<br /><br />2. Love the Salesforce integration! But it'd be great if you could add Hubspot too.<br />Category: Integration, Feature Request<br />Sentiment: Positive<br />Priority: Medium<br /><br />3. Your pricing is ridiculous! \$99/mo for basic features? I'm switching to Competitor X.<br />Category: Pricing<br />Sentiment: Negative<br />Priority: High<br /><br />4. The mobile app keeps crashing when I try to upload large files (>50MB). This is critical for our field agents.<br />Category: Performance<br />Sentiment: Negative<br />Priority: High<br /><br />5. Overall, I'm happy with the product. The UI is intuitive, and the customer support is top-notch. Keep it up!<br />Category: UI/UX, Other (Customer Support)<br />Sentiment: Positive<br />Priority: Low |
+
+</Accordion>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 3. Let Claude Think (Chain of Thought Prompting)
+
+When tackling complex problems, allow Claude to work through them step by step. This approach, known as chain of thought prompting, often leads to more accurate and thoughtful responses. The model can break down complex tasks, reason through different approaches, and arrive at better solutions.
+
+### 4. Use XML Tags to Structure Your Prompts
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When your prompts involve multiple components like context, instructions, and examples, XML tags can be a game-changer. They help Claude parse your prompts more accurately, leading to higher-quality outputs.
+
+<Tip>**XML tip**: Use tags like `<instructions>`, `<example>`, and `<formatting>` to clearly separate different parts of your prompt. This prevents Claude from mixing up instructions with examples or context.</Tip>
+
+#### Why use XML tags?
+
+- **Clarity:** Clearly separate different parts of your prompt and ensure your prompt is well structured.
+- **Accuracy:** Reduce errors caused by Claude misinterpreting parts of your prompt.
+- **Flexibility:** Easily find, add, remove, or modify parts of your prompt without rewriting everything.
+- **Parseability:** Having Claude use XML tags in its output makes it easier to extract specific parts of its response by post-processing.
+
+<Note>There are no canonical "best" XML tags that Claude has been trained with in particular, although we recommend that your tag names make sense with the information they surround.</Note>
+
+#### Tagging best practices
+
+1. **Be consistent**: Use the same tag names throughout your prompts, and refer to those tag names when talking about the content (e.g, `Using the contract in <contract> tags...`).
+2. **Nest tags**: You should nest tags `<outer><inner></inner></outer>` for hierarchical content.
+
+<Tip>**Power user tip**: Combine XML tags with other techniques like multishot prompting (`<examples>`) or chain of thought (`<thinking>`, `<answer>`). This creates super-structured, high-performance prompts.</Tip>
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Generating financial reports">
+    Without XML tags, Claude misunderstands the task and generates a report that doesn't match the required structure or tone. After substitution, there is also a chance that Claude misunderstands where one section (like the Q1 report example) stops and another begins.
+
+    | Role      | No XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | With XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+    | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | You're a financial analyst at AcmeCorp. Generate a Q2 financial report for our investors. Include sections on Revenue Growth, Profit Margins, and Cash Flow, like with this example from last year: \{\{Q1\_REPORT}}. Use data points from this spreadsheet: \{\{SPREADSHEET\_DATA}}. The report should be extremely concise, to the point, professional, and in list format. It should and highlight both strengths and areas for improvement.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | You're a financial analyst at AcmeCorp. Generate a Q2 financial report for our investors.<br /><br />AcmeCorp is a B2B SaaS company. Our investors value transparency and actionable insights.<br /><br />Use this data for your report:\<data>\{\{SPREADSHEET\_DATA}}\</data><br /><br />\<instructions><br />1. Include sections: Revenue Growth, Profit Margins, Cash Flow.<br />2. Highlight strengths and areas for improvement.<br />\</instructions><br /><br />Make your tone concise and professional. Follow this structure:<br />\<formatting\_example>\{\{Q1\_REPORT}}\</formatting\_example>                                                                                                                                                                                                                  |
+    | Assistant | Q2 Financial Report for AcmeCorp Investors<br /><br />Dear Valued Investors,<br /><br />I am pleased to present our Q2 financial report, showcasing AcmeCorp's continued growth and resilience in the B2B SaaS market.<br /><br />1. Revenue Growth:<br />Our Q2 revenue reached \$15.2M, a 22% YoY increase. This growth is primarily driven by a 30% expansion in our enterprise client base. However, our SMB segment saw a slight decline of 5%, which we aim to address through targeted marketing initiatives in Q3.<br /><br />2. Profit Margins:<br />Gross margin improved to 72% (up 3% from Q1) due to infrastructure optimizations. EBITDA margin, however, dipped to 18% (down 2%) as we invested heavily in R\&D for our upcoming AI-driven features.<br /><br />3. Cash Flow:<br />Operating cash flow remains strong at \$4.1M. Our cash reserves stand at \$28M, providing a 15-month runway at current burn rate. We did see a 20% increase in customer acquisition costs, which we're addressing through more efficient sales strategies.<br /><br />In summary, AcmeCorp's core financials remain robust. We're balancing growth investments with prudent cash management. Our focus for Q3 will be revitalizing SMB growth and optimizing sales efficiency.<br /><br />Thank you for your continued trust.<br /><br />Sincerely,<br />CFO, AcmeCorp | Q2 Financial Report for AcmeCorp Investors\</output><br /><br />Revenue Growth:<br />- Q2 revenue: \$15.2M (22% YoY ↑)<br />- Enterprise clients: 30% ↑<br />- SMB segment: 5% ↓<br />  Action: Targeted Q3 marketing<br /><br />Profit Margins:<br />- Gross margin: 72% (3% ↑ from Q1)<br />  Reason: Infrastructure optimizations<br />- EBITDA margin: 18% (2% ↓)<br />  Reason: R\&D investment in AI features<br /><br />Cash Flow:<br />- Operating cash flow: \$4.1M (strong)<br />- Cash reserves: \$28M (15-month runway)<br />- Customer acquisition cost: 20% ↑<br />  Action: Optimize sales strategies<br /><br />Outlook:<br />- Core financials: Robust<br />- Q3 focus: Revitalize SMB, optimize sales<br /><br />Management remains committed to balancing growth investments with financial discipline. |
+
+  </Accordion>
+
+  <Accordion title="Example: Legal contract analysis">
+    Without XML tags, Claude's analysis is disorganized and misses key points. With tags, it provides a structured, thorough analysis that a legal team can act on.
+
+    | Role      | No XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | With XML Tags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+    | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User      | Analyze this software licensing agreement for potential risks and liabilities: \{\{CONTRACT}}. Focus on indemnification, limitation of liability, and IP ownership clauses. Also, note any unusual or concerning terms. Here's our standard contract for reference: \{\{STANDARD\_CONTRACT}}. Give a summary of findings and recommendations for our legal team.                                                                                                                                                                                                                                                                                                                    | Analyze this software licensing agreement for legal risks and liabilities.<br /><br />We're a multinational enterprise considering this agreement for our core data infrastructure.<br /><br />\<agreement><br />\{\{CONTRACT}}\</agreement><br /><br />This is our standard contract for reference:<br />\<standard\_contract>\{\{STANDARD\_CONTRACT}}\</standard\_contract><br /><br />\<instructions><br />1. Analyze these clauses:<br />   - Indemnification<br />   - Limitation of liability<br />   - IP ownership<br /><br />2. Note unusual or concerning terms.<br /><br />3. Compare to our standard contract.<br /><br />4. Summarize findings in \<findings> tags.<br /><br />5. List actionable recommendations in \<recommendations> tags.\</instructions>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+    | Assistant | The provided software licensing agreement presents several concerning aspects. The indemnification clause is overly broad, potentially exposing us to significant liabilities. The limitation of liability section caps damages at a mere \$500, which is inadequate for our enterprise-level usage. Regarding IP, the agreement grants the vendor joint ownership of any modifications or integrations we create.<br /><br />In summary, this agreement is not in our best interest. It exposes us to undue risk, limits our recourse in case of failures, and compromises our intellectual property rights. I recommend renegotiating these terms or seeking alternative vendors. | \<findings><br />1. Indemnification (Clause 8):<br />   - Issue: Overly broad. We indemnify vendor against "any and all claims" arising from our use.<br />   - Risk: Could hold us liable even for vendor's negligence or product defects.<br />   - Deviation: Our standard limits indemnity to claims arising from our violation of agreement.<br /><br />2. Limitation of Liability (Clause 9):<br />   - Issue: Caps all damages at \$500, including direct damages.<br />   - Risk: Grossly inadequate for enterprise use. A critical failure could cost millions.<br />   - Deviation: Our standard allows for direct damages up to 12 months of fees paid.<br /><br />3. IP Ownership (Clause 12):<br />   - Issue: Grants vendor joint ownership of our modifications/integrations.<br />   - Risk: Vendor could use or sell our proprietary algorithms or data insights.<br />   - Deviation: Our standard retains full ownership of our work.<br /><br />4. Unusual Terms:<br />   - Clause 5.3: Vendor can use our usage data for "any purpose."<br />   - Clause 7.2: Vendor can terminate for "convenience" with only 7 days' notice.<br />   - Clause 11: No warranties of any kind, even for basic merchantability.<br />\</findings><br /><br />\<recommendations><br />1. Reject this agreement. Risks far outweigh benefits for an enterprise.<br />2. Counter-propose:<br />   - Indemnification: Limit to claims arising from our violation of agreement.<br />   - Liability: Cap at 12 months' fees for direct damages; negotiate for indirect.<br />   - IP: Full ownership of our modifications/integrations.<br />   - Data Use: Restrict to service improvement only.<br />   - Termination: Minimum 90 days' notice; only for cause.<br />   - Warranties: Demand basic merchantability and fitness for purpose.<br />3. If vendor refuses, explore alternative providers or in-house solutions.<br />4. Engage legal counsel for contract negotiation given high stakes.<br />\</recommendations> |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 5. Give Claude a Role with a System Prompt
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When using Claude, you can dramatically improve its performance by using the `system` parameter to give it a role. This technique, known as role prompting, is the most powerful way to use system prompts with Claude.
+
+The right role can turn Claude from a general assistant into your virtual domain expert!
+
+<Tip>**System prompt tips**: Use the `system` parameter to set Claude's role. Put everything else, like task-specific instructions, in the `user` turn instead.</Tip>
+
+#### Why use role prompting?
+
+- **Enhanced accuracy:** In complex scenarios like legal analysis or financial modeling, role prompting can significantly boost Claude's performance.
+- **Tailored tone:** Whether you need a CFO's brevity or a copywriter's flair, role prompting adjusts Claude's communication style.
+- **Improved focus:** By setting the role context, Claude stays more within the bounds of your task's specific requirements.
+
+#### How to give Claude a role
+
+Use the `system` parameter in the [Messages API](/en/api/messages) to set Claude's role:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-3-7-sonnet-20250219",
+    max_tokens=2048,
+    system="You are a seasoned data scientist at a Fortune 500 company.", # <-- role prompt
+    messages=[
+        {"role": "user", "content": "Analyze this dataset for anomalies: <dataset>{{DATASET}}</dataset>"}
+    ]
+)
+
+print(response.content)
+```
+
+<Tip>**Role prompting tip**: Experiment with roles! A `data scientist` might see different insights than a `marketing strategist` for the same data. A `data scientist specializing in customer insight analysis for Fortune 500 companies` might yield different results still!</Tip>
+
+#### Examples
+
+##### Example 1: Legal contract analysis
+
+Without a role, Claude might miss critical issues:
+
+<Accordion title="Legal contract analysis without role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | Analyze this software licensing agreement for potential risks:<br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Focus on indemnification, liability, and IP ownership.                                                                                                                                                                                                                                                                                                                              |
+  | Assistant | Here's a summary of the key points in the software licensing agreement:<br /><br />1. Indemnification (Section 8):<br />   - We indemnify the vendor against claims arising from our use.<br /><br />2. Limitation of Liability (Section 9):<br />   - Damages capped at \$500.<br /><br />3. IP Ownership (Section 12):<br />   - We retain ownership of our modifications.<br /><br />Overall, the agreement seems standard. The indemnification and liability clauses are typical, and we maintain our IP rights. |
+</Accordion>
+
+With a role, Claude catches critical issues that could cost millions:
+
+<Accordion title="Legal contract analysis with role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+  | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | You are the General Counsel of a Fortune 500 tech company. We're considering this software licensing agreement for our core data infrastructure:<br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Analyze it for potential risks, focusing on indemnification, liability, and IP ownership. Give your professional opinion.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+  | Assistant | I've reviewed the software licensing agreement, and I have serious concerns that could expose our company to significant risks:<br /><br />1. Indemnification (Section 8):<br />   - Critical Issue: We indemnify the vendor against "any and all claims" arising from our use.<br />   - Risk: This could hold us liable even for the vendor's negligence or product defects.<br />   - Recommendation: Reject. Limit our indemnity to claims arising from our violation of the agreement.<br /><br />2. Limitation of Liability (Section 9):<br />   - Critical Issue: Damages capped at \$500, including direct damages.<br />   - Risk: Grossly inadequate. A critical failure in our data infrastructure could cost us millions in lost revenue and reputational damage.<br />   - Recommendation: Reject. Negotiate for cap at 12 months of fees for direct damages, and carve-outs for data breaches.<br /><br />3. IP Ownership (Section 12):<br />   - Critical Issue: Vendor gains joint ownership of our modifications and integrations.<br />   - Risk: They could use or sell our proprietary algorithms or data insights to competitors.<br />   - Recommendation: Reject. We must retain full ownership of our work.<br /><br />Professional Opinion: Do not sign this agreement. It is grossly unfavorable and exposes us to unacceptable levels of risk. If the vendor refuses to renegotiate these terms, I strongly advise exploring alternative providers or accelerating our in-house solution. The potential costs of proceeding with this agreement far outweigh any short-term gains. |
+</Accordion>
+
+##### Example 2: Financial analysis
+
+Without a role, Claude's analysis lacks depth:
+
+<Accordion title="Financial analysis without role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | Analyze this dataset of our Q2 financials:<br />\<data><br />\{\{FINANCIALS}}<br />\</data><br /><br />Highlight key trends and recommend actions.                                                                                                                                                                                                                                                                                                                               |
+  | Assistant | Here's a summary of your Q2 financials:<br /><br />1. Revenue: \$15.2M, up 22% YoY. Enterprise client base grew 30%.<br />2. Gross Margin: 72%, up 3% from Q1.<br />3. EBITDA Margin: 18%, down 2% due to R\&D investments.<br />4. Cash Flow: \$4.1M operating, \$28M in reserves.<br /><br />Overall, financials look strong with revenue growth and healthy margins. Increased R\&D spending is impacting profitability but could pay off long-term. Maintain current course. |
+</Accordion>
+
+With a role, Claude delivers actionable insights:
+
+<Accordion title="Financial analysis with role prompting">
+  | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+  | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | User      | You are the CFO of a high-growth B2B SaaS company. We're in a board meeting discussing our Q2 financials:<br />\<data><br />\{\{FINANCIALS}}<br />\</data><br /><br />Analyze key trends, flag concerns, and recommend strategic actions. Our investors want aggressive growth but are wary of our burn rate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+  | Assistant | Board members, here's my analysis of our Q2 financials:<br /><br />1. Revenue (\$15.2M, +22% YoY):<br />   - Insight: Enterprise growth (+30%) is outpacing overall growth.<br />   - Flag: SMB segment declined 5%.<br />   - Action: Reallocate 20% of SMB marketing budget to enterprise sales. Task product to simplify SMB onboarding.<br /><br />2. Margins (Gross: 72%, +3% QoQ; EBITDA: 18%, -2% QoQ):<br />   - Insight: Infrastructure optimizations boosted gross margins.<br />   - Flag: R\&D spend on AI features dented EBITDA.<br />   - Action: No change. Our AI roadmap is critical for enterprise stickiness.<br /><br />3. Cash (\$4.1M OCF, \$28M reserves):<br />   - Insight: 15-month runway at current burn.<br />   - Flag: CAC up 20%, eroding LTV/CAC.<br />   - Action: Freeze non-essential hires. Implement sales funnel analytics to cut CAC by 15% in Q3.<br /><br />Strategic Stance: We're threading the needle between growth and burn. Enterprise focus is our growth engine—invest there. But watch SMB churn; it could bleed into enterprise. Our AI bet is sound, but we must convert it to ARR by Q4, or we cut R\&D by 30%.<br /><br />In sum: Double down on enterprise, streamline SMB, optimize sales, and monetize AI. Questions? |
+</Accordion>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 6. Chain Complex Prompts for Stronger Performance
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+When working with complex tasks, Claude can sometimes drop the ball if you try to handle everything in a single prompt. Chain of thought (CoT) prompting is great, but what if your task has multiple distinct steps that each require in-depth thought?
+
+Enter prompt chaining: breaking down complex tasks into smaller, manageable subtasks.
+
+#### Why chain prompts?
+
+1. **Accuracy**: Each subtask gets Claude's full attention, reducing errors.
+2. **Clarity**: Simpler subtasks mean clearer instructions and outputs.
+3. **Traceability**: Easily pinpoint and fix issues in your prompt chain.
+
+#### When to chain prompts
+
+Use prompt chaining for multi-step tasks like research synthesis, document analysis, or iterative content creation. When a task involves multiple transformations, citations, or instructions, chaining prevents Claude from dropping or mishandling steps.
+
+**Remember:** Each link in the chain gets Claude's full attention!
+
+<Tip>**Debugging tip**: If Claude misses a step or performs poorly, isolate that step in its own prompt. This lets you fine-tune problematic steps without redoing the entire task.</Tip>
+
+#### How to chain prompts
+
+1. **Identify subtasks**: Break your task into distinct, sequential steps.
+2. **Structure with XML for clear handoffs**: Use XML tags to pass outputs between prompts.
+3. **Have a single-task goal**: Each subtask should have a single, clear objective.
+4. **Iterate**: Refine subtasks based on Claude's performance.
+
+##### Example chained workflows:
+
+- **Multi-step analysis**: See the legal and business examples below.
+- **Content creation pipelines**: Research → Outline → Draft → Edit → Format.
+- **Data processing**: Extract → Transform → Analyze → Visualize.
+- **Decision-making**: Gather info → List options → Analyze each → Recommend.
+- **Verification loops**: Generate content → Review → Refine → Re-review.
+
+<Tip>**Optimization tip**: For tasks with independent subtasks (like analyzing multiple docs), create separate prompts and run them in parallel for speed.</Tip>
+
+##### Prompt Folding & Dynamic Generation
+
+Design prompts that can dynamically generate more specialized sub-prompts based on context or previous outputs in multi-stage workflows. This creates adaptive agentic systems that tailor their approach based on what they discover.
+
+**Example Pattern:**
+1. **Classifier prompt** that analyzes the input and determines the best approach
+2. **Dynamic sub-prompt generation** based on the classification
+3. **Specialized execution** using the generated sub-prompt
+
+```
+Step 1: Analyze this customer query and determine the best response approach.
+If it's a technical issue → generate a detailed troubleshooting prompt
+If it's a billing question → generate a billing-specific prompt  
+If it's a feature request → generate a product feedback prompt
+
+Step 2: Use the generated prompt to handle the specific case
+```
+
+This technique allows for more sophisticated and context-aware agent behaviors.
+
+##### Advanced: Self-correction chains
+
+You can chain prompts to have Claude review its own work! This catches errors and refines outputs, especially for high-stakes tasks.
+
+<AccordionGroup>
+  <Accordion title="Example: Self-correcting research summary">
+    #### Prompt 1
+
+    | Role                         | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+    | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                         | Summarize this medical research paper.<br /><br />\<paper>\{\{RESEARCH\_PAPER}}\</paper><br /><br />Focus on methodology, findings, and clinical implications.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+    | Assistant<br />\{\{SUMMARY}} | Methodology: Double-blind RCT with 500 Type 2 diabetes patients. Group A (n=250) received novel GLP-1/GIP dual agonist; Group B (n=250) received standard GLP-1 agonist. 24-week trial, primary endpoint: HbA1c reduction.<br /><br />Findings:<br />- Group A: 1.8% mean HbA1c reduction<br />- Group B: 1.1% mean HbA1c reduction<br />- 68% of Group A vs. 52% of Group B achieved HbA1c \<7%<br />- Group A: 5.2kg mean weight loss<br />- Group B: 3.1kg mean weight loss<br /><br />Safety: Similar adverse event profiles, no serious events attributed to treatment.<br /><br />Clinical Implications: Dual agonist shows superior glycemic control and weight loss compared to standard therapy. Could be a game-changer, especially for obese diabetics. |
+
+    #### Prompt 2
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+    | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | Your task is to provide feedback on a research paper summary. Here is a summary of a medical research paper:<br />\<summary><br />\{\{SUMMARY}}<br />\</summary><br /><br />Here is the research paper:<br />\<paper><br />\{\{RESEARCH\_PAPER}}<br />\</paper><br /><br />Review this summary for accuracy, clarity, and completeness on a graded A-F scale.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | Assistant<br />\{\{FEEDBACK}} | 1. Accuracy: A<br />   - Correctly reported key stats: HbA1c reductions, weight loss.<br />   - Accurately noted safety profile and lack of serious adverse events.<br />   - Assertion of "game-changer" is justified by significantly better outcomes.<br /><br />2. Clarity: A-<br />   - Concise and well-structured with clear sections.<br />   - Good use of comparative language (e.g., "up 3% from Q1") for context.<br />   - Minor issue: Acronyms like "RCT," "GLP-1," and "GIP" not defined. Consider spelling out first use.<br /><br />3. Completeness: B+<br />   - Covers all requested areas: methodology, findings, clinical implications.<br />   - Missing: Baseline characteristics of groups (were they well-matched?).<br />   - Missing: Any secondary endpoints (e.g., blood pressure, lipids).<br />   - Consider: Long-term implications or need for further research.<br /><br />Overall, the summary is accurate and clear, providing key insights for a quick grasp of the study. To elevate to A+, define acronyms, mention group baseline stats, note any secondary outcomes, and briefly touch on the need for long-term studies. |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | Your task is to improve a paper summary given feedback. Here is the first draft of a medical research paper:<br />\<summary><br />\{\{SUMMARY}}<br />\</summary><br /><br />Here is the research paper:<br />\<paper><br />\{\{RESEARCH\_PAPER}}<br />\</paper><br /><br />Here is the feedback:<br />\<feedback><br />\{\{FEEDBACK}}<br />\</feedback><br /><br />Update the summary based on the feedback.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+    | Assistant | Methodology: Double-blind randomized controlled trial (RCT) with 500 Type 2 diabetes patients. Group A (n=250) received a novel glucagon-like peptide-1/glucose-dependent insulinotropic polypeptide (GLP-1/GIP) dual agonist; Group B (n=250) received a standard GLP-1 agonist. The 24-week trial's primary endpoint was HbA1c reduction. Groups were well-matched for age, BMI, and baseline HbA1c.<br /><br />Findings:<br />- Group A: 1.8% mean HbA1c reduction<br />- Group B: 1.1% mean HbA1c reduction<br />- 68% of Group A vs. 52% of Group B achieved HbA1c \<7%<br />- Group A: 5.2kg mean weight loss<br />- Group B: 3.1kg mean weight loss<br /><br />Secondary endpoints showed improvements in blood pressure and lipid profiles for both groups, with Group A showing slightly better results.<br /><br />Safety: Similar adverse event profiles, with no serious events attributed to either treatment.<br /><br />Clinical Implications: The dual GLP-1/GIP agonist demonstrates superior glycemic control and weight loss compared to standard GLP-1 therapy. These results suggest it could be a significant advancement, particularly for obese diabetics. However, longer-term studies are needed to confirm sustained efficacy and safety, as well as to investigate potential benefits on cardiovascular outcomes. |
+
+  </Accordion>
+</AccordionGroup>
+
+#### Examples
+
+<AccordionGroup>
+  <Accordion title="Example: Analyzing a legal contract (without chaining)">
+    Note that Claude misses the instruction to provide proposed changes in its email draft.
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+    | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | You're our Chief Legal Officer. Review this SaaS contract for risks, focusing on data privacy, SLAs, and liability caps.<br /><br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Then draft an email to the vendor with your concerns and proposed changes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+    | Assistant | After reviewing the SaaS contract, I've identified several concerns:<br /><br />1. Data Privacy (Section 7):<br />   - Issue: Vendor has broad rights to use client data for "service improvement."<br />   - Risk: Could lead to unauthorized data sharing or monetization.<br /><br />2. SLAs (Section 5):<br />   - Issue: 99.5% uptime guarantee is below industry standard.<br />   - Risk: Excessive downtime could impact our operations.<br /><br />3. Liability (Section 9):<br />   - Issue: Cap set at 3 months of fees.<br />   - Risk: Inadequate for potential data breaches or service failures.<br /><br />Draft email:<br /><br />Dear \{\{VENDOR}},<br /><br />After reviewing the SaaS agreement, we have concerns:<br /><br />1. Data Privacy: We require that our data only be used for direct service provision, not broad "service improvement." Please amend Section 7.<br /><br />2. SLAs: 99.5% uptime is insufficient. We need 99.99% with clearly defined penalties. Please revise Section 5.<br /><br />3. Liability: The current cap of 3 months' fees is inadequate. We propose a cap of 12 months' fees, with no cap for data breaches or willful misconduct.<br /><br />We value our potential partnership and believe these changes will set us up for success. Please send a revised agreement.<br /><br />Best regards,<br />\{\{CLO\_NAME}} |
+
+  </Accordion>
+
+  <Accordion title="Example: Analyzing a legal contract (with chaining)">
+    #### Prompt 1
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | You're our Chief Legal Officer. Review this SaaS contract for risks, focusing on data privacy, SLAs, and liability caps.<br /><br />\<contract><br />\{\{CONTRACT}}<br />\</contract><br /><br />Output your findings in \<risks> tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+    | Assistant<br />\{\{CONCERNS}} | 1. Data Privacy (Section 7):<br />   - Issue: Vendor has broad rights to use client data for "service improvement."<br />   - Risk: Could lead to unauthorized data sharing or monetization of client data.<br />   - Impact: Potential breach of client trust, regulatory fines (GDPR, CCPA).<br /><br />2. SLAs (Section 5):<br />   - Issue: 99.5% uptime guarantee is below industry standard (typically 99.99%).<br />   - Risk: Up to 43.8 hours of downtime per year vs. 52.6 minutes at 99.99%.<br />   - Impact: Operational disruptions, revenue loss, client dissatisfaction.<br /><br />3. Liability (Section 9):<br />   - Issue: Liability cap set at 3 months of fees.<br />   - Risk: Inadequate for potential data breaches, IP theft, or prolonged service failures.<br />   - Impact: Insufficient compensation for damages that could far exceed the cap, like class-action lawsuits or regulatory fines. |
+
+    #### Prompt 2
+
+    | Role                       | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+    | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                       | Draft an email to a SaaS product vendor outlining the following concerns and proposing changes. Here are the concerns:<br />\<concerns><br />\{\{CONCERNS}}<br />\</concerns><br /><br />                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | Assistant<br />\{\{EMAIL}} | Dear \{\{VENDOR}},<br /><br />After a thorough review of the proposed SaaS agreement, our legal team has identified several high-priority concerns that must be addressed before we can proceed:<br /><br />1. Data Privacy (Section 7):<br />   - Current: Broad rights to use client data for "service improvement."<br />   - Concern: Potential unauthorized data sharing or monetization.<br />   - Proposed Change: Limit data use to direct service provision. Any use for improvement, analytics, or marketing must be opt-in, revocable, and anonymized.<br /><br />2. SLAs (Section 5):<br />   - Current: 99.5% uptime guarantee.<br />   - Concern: Up to 43.8 hours of downtime per year, risking operational disruptions.<br />   - Proposed Change: 99.99% uptime with tiered service credits. E.g., 10% credit for \<99.99%, 25% for \<99.9%, 50% for \<99.5%.<br /><br />3. Liability (Section 9):<br />   - Current: Cap at 3 months of fees.<br />   - Concern: Grossly inadequate for data breaches, IP theft, or prolonged outages.<br />   - Proposed Change: 12 months' fees for general liability. Uncapped for data breaches, willful misconduct, IP infringement.<br /><br />These changes are non-negotiable for us. They align with industry standards and our commitment to data security, operational excellence, and fiduciary responsibility. We value the potential of our partnership, and addressing these will set a strong foundation.<br /><br />Please have your legal team review and incorporate these changes. We're happy to discuss further to ensure mutual understanding and agreement.<br /><br />Best regards,<br />\{\{CLO\_NAME}} |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+    | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User      | Your task is to review an email and provide feedback. Here is the email:<br />\<email><br />\{\{EMAIL}}<br />\</email><br /><br />Give feedback on tone, clarity, and professionalism.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | Assistant | 1. Tone:<br />   - Professional and assertive without being confrontational.<br />   - Use of "non-negotiable" is strong but justified given the criticality of the issues.<br />   - Collaborative language ("we value," "happy to discuss") balances the firmness, maintaining a constructive tone.<br /><br />2. Clarity:<br />   - Excellent structuring: Current state, concern, and proposed change for each issue.<br />   - Technical terms (e.g., "EBITDA," "tiered service credits") are appropriate for a B2B SaaS context.<br />   - Action items are clear: vendor's legal team to review and incorporate changes.<br /><br />3. Professionalism:<br />   - Focuses on mutual benefit and industry standards, not just our demands.<br />   - Mentions broader responsibilities (data security, operational excellence, fiduciary duty), elevating the discussion.<br />   - Offers further discussion, showing commitment to understanding and resolving issues.<br /><br />Overall, the email strikes the right balance of assertiveness and collaboration. It clearly articulates our concerns, proposes specific solutions, and maintains a professional, partnership-oriented tone. No revisions needed; proceed with sending. |
+
+  </Accordion>
+
+  <Accordion title="Example: Multitenancy strategy review">
+    #### Prompt 1
+
+    | Role                          | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+    | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User                          | As a senior solutions architect, review and analyze this multitenancy strategy for our new enterprise SaaS product.<br /><br />\<strategy><br />\{\{STRATEGY}}<br />\</strategy><br /><br />Focus on scalability, security, and cost-effectiveness.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    | Assistant<br />\{\{ANALYSIS}} | 1. Scalability:<br />   + Database sharding by tenant reduces contention, supports high growth.<br />   + Microservices allow independent scaling of components.<br />   - Shared app servers could bottleneck under extreme load.<br />   - No mention of auto-scaling or load balancing for app tier.<br /><br />2. Security:<br />   + Tenant data isolation via sharding mitigates data leaks.<br />   + JWT with short expiry and refresh tokens is industry best practice.<br />   - No mention of encryption (at rest, in transit) or key management.<br />   - IAM strategy lacks detail on roles, permissions, or RBAC.<br /><br />3. Cost-effectiveness:<br />   + Shared app servers reduce idle resource costs.<br />   + Serverless functions for infrequent tasks optimize costs.<br />   - Per-tenant DB could increase costs at scale vs. optimized multi-tenant DB.<br />   - No discussion of reserved instances or spot instances for cost saving. |
+
+    #### Prompt 2
+
+    | Role                               | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+    | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | User                               | Draft a strategy review document for engineering leadership based on this analysis of a multitenancy strategy.<br /><br />\<strategy><br />\{\{STRATEGY}}<br />\</strategy><br /><br />\<analysis><br />\{\{ANALYSIS}}<br />\</analysis><br /><br />Include an executive summary, detailed analysis, and recommendations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+    | Assistant<br />\{\{STRATEGY\_DOC}} | # Multitenancy Strategy Review: SaaS Enterprise Product<br /><br />## Executive Summary<br />The proposed strategy demonstrates a solid foundation in scalability and security principles but has gaps in implementation details. It excels in data isolation and component-level scaling but lacks robust app-tier scaling and advanced security measures. Cost optimizations are present but may falter at high scale. With targeted enhancements, this strategy can effectively support our enterprise SaaS ambitions.<br /><br />## Detailed Analysis<br /><br />### 1. Scalability: B+<br /><br />Strengths:<br />- Database sharding by tenant is excellent. It minimizes query latency, supports high data growth, and facilitates seamless per-tenant scaling.<br />- Microservices architecture allows scaling individual components based on demand, crucial for handling diverse enterprise workloads.<br /><br />Weaknesses:<br />- Shared application servers risk becoming a bottleneck. As tenant count and traffic grow, these could degrade performance across all tenants.<br />- Absence of auto-scaling and load balancing for the app tier is a critical oversight. These are essential for handling traffic spikes without over-provisioning.<br /><br />### 2. Security: B-<br /><br />Strengths:<br />- Sharded databases provide strong tenant data isolation, mitigating risks of data leaks or unauthorized access between tenants.<br />- JWT with short expiry and refresh tokens align with OWASP best practices, reducing token vulnerability windows.<br /><br />Weaknesses:<br />- No mention of data encryption at rest or in transit (TLS 1.3). This is non-negotiable for enterprise data.<br />- Key management strategy is missing. How are encryption keys, JWT secrets, and DB credentials managed and rotated?<br />- IAM lacks depth. We need RBAC with well-defined roles, attribute-based access control (ABAC) for fine-grained permissions, and integration with enterprise identity providers (SAML, OIDC).<br /><br />### 3. Cost-effectiveness: B<br /><br />Strengths:<br />- Shared app servers reduce idle capacity costs, good for steady-state traffic.<br />- Serverless for infrequent tasks (e.g., reporting) is smart; pay only when these resources are used.<br /><br />Weaknesses:<br />- Per-tenant databases may not be cost-effective at scale compared to a well-designed multi-tenant database with robust data partitioning.<br />- No mention of cost-saving measures like reserved instances for predictable workloads or spot instances for fault-tolerant tasks.<br />- Lack of app-tier auto-scaling could lead to over-provisioning, increasing costs.<br /><br />## Recommendations<br /><br />1. **App Tier Resilience**: Implement auto-scaling with Kubernetes or cloud-native services (EKS, GKE). Deploy across availability zones with a CDN for static assets.<br /><br />2. **Security Hardening**:<br />   a. Encrypt data at rest (AES-256) and in transit (TLS 1.3).<br />   b. Use a managed KMS (AWS KMS, GCP KMS) for key management.<br />   c. Enhance IAM with RBAC, ABAC, and SAML/OIDC for enterprise SSO.<br /><br />3. **Cost Optimization**:<br />   a. Evaluate columnar multi-tenant DB (e.g., Snowflake) vs. sharding at scale.<br />   b. Use reserved instances for app servers, spot instances for non-critical workloads.<br />   c. Implement proactive monitoring and right-sizing to avoid overprovisioning.<br /><br />4. **Proof of Concept (PoC)**: Before full implementation, conduct a PoC with a high-scale simulation:<br />   a. Test sharded DB vs. optimized multi-tenant DB for cost and performance.<br />   b. Stress-test app tier with simulated enterprise-level traffic spikes.<br />   c. Conduct third-party security audit, focusing on data isolation and access controls.<br /><br />With these enhancements, our multi-tenancy strategy will be enterprise-grade: scalable, secure, and cost-effective. The PoC will validate our design choices and instill confidence in our enterprise clients. |
+
+    #### Prompt 3
+
+    | Role      | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | User      | Grade this strategy review document for clarity, actionability, and alignment with enterprise priorities. <br /><br />\<priorities><br />\{\{PRIORITIES}}<br />\</priorities><br /><br />\<strategy\_doc><br />\{\{STRATEGY\_DOC}}<br />\</strategy\_doc>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+    | Assistant | 1. Clarity: A<br />   + Clear structure with Executive Summary, Detailed Analysis, and Recommendations.<br />   + Analysis uses a grading system (B+, B-) for quick grasp of strengths/weaknesses.<br />   + Technical terms (RBAC, ABAC, TLS) are explained or contextualized, aiding non-technical leadership.<br />   + Visual aids (bullet points, indentation) enhance readability.<br /><br />2. Actionability: A-<br />   + Recommendations are specific and technical (e.g., "Implement auto-scaling with Kubernetes").<br />   + PoC plan with clear objectives provides a roadmap.<br />   + Missing: Timelines, resource requirements, or team assignments for each recommendation.<br />   + Consider: Add a "Next Steps" section with immediate actions, roles, and a high-level timeline.<br /><br />3. Enterprise Alignment: A+<br />   + Directly addresses enterprise priorities:<br />     - Scalability: Discusses handling enterprise-level traffic spikes.<br />     - Security: Focuses on data isolation, encryption, and enterprise IAM.<br />     - Cost: Strategies align with enterprise FinOps (reserved instances, right-sizing).<br />   + PoC with "high-scale simulation" and security audit shows commitment to enterprise-grade quality.<br />   + Language resonates with enterprise concerns: "unacceptable risk," "enterprise-grade," "instill confidence."<br /><br />Overall, the document excels in clarity and enterprise alignment. The actionability is strong but could be elevated to A+ with a "Next Steps" section. The technical depth, coupled with clear explanations, makes this highly effective for both technical and non-technical leadership. Great work! |
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 7. Meta-Prompting: Let Claude Improve Your Prompts
+
+One of the most powerful techniques is using Claude itself to help refine and improve your prompts. Claude understands its own capabilities and limitations, making it an excellent prompt engineering assistant.
+
+#### How to Use Meta-Prompting
+
+1. **Show Claude your current prompt** along with examples of good and bad outputs
+2. **Ask Claude to critique the prompt** and identify areas for improvement  
+3. **Request specific improvements** like "make this prompt more specific" or "add better examples"
+4. **Iterate on the suggestions** to create increasingly effective prompts
+
+#### Example Meta-Prompting Session
+
+```
+Current prompt: "Analyze the customer feedback and tell me what to improve."
+
+Claude, please critique this prompt and make it better. Here are some examples of outputs I received:
+- [Include actual outputs showing problems]
+
+Make the prompt more specific, add structure, and include examples that would lead to more actionable insights.
+```
+
+Claude can suggest improvements like:
+- Adding role context ("You are a product manager...")
+- Structuring output requirements (using XML tags, bullet points)
+- Including specific examples of good analysis
+- Adding constraints and edge case handling
+
+#### Benefits of Meta-Prompting
+
+- **Leverages Claude's self-knowledge** about what works best
+- **Saves time** compared to manual trial-and-error iteration
+- **Reveals blind spots** you might not have considered
+- **Creates prompt templates** that can be reused across similar tasks
+
+### 8. Long Context Tips
+
+<Note>
+  While these tips apply broadly to all Claude models, you can find prompting tips specific to extended thinking models [here](/en/docs/build-with-claude/prompt-engineering/extended-thinking-tips).
+</Note>
+
+Claude's extended context window (200K tokens for Claude 3 models) enables handling complex, data-rich tasks. This guide will help you leverage this power effectively.
+
+#### Essential tips for long context prompts
+
+- **Put longform data at the top**: Place your long documents and inputs (\~20K+ tokens) near the top of your prompt, above your query, instructions, and examples. This can significantly improve Claude's performance across all models.
+
+  <Note>Queries at the end can improve response quality by up to 30% in tests, especially with complex, multi-document inputs.</Note>
+
+- **Structure document content and metadata with XML tags**: When using multiple documents, wrap each document in `<document>` tags with `<document_content>` and `<source>` (and other metadata) subtags for clarity.
+
+  <Accordion title="Example multi-document structure">
+    ```xml
+    <documents>
+      <document index="1">
+        <source>annual_report_2023.pdf</source>
+        <document_content>
+          {{ANNUAL_REPORT}}
+        </document_content>
+      </document>
+      <document index="2">
+        <source>competitor_analysis_q2.xlsx</source>
+        <document_content>
+          {{COMPETITOR_ANALYSIS}}
+        </document_content>
+      </document>
+    </documents>
+
+  Analyze the annual report and competitor analysis. Identify strategic advantages and recommend Q3 focus areas.
+
+  ```
+  </Accordion>
+
+  ```
+
+- **Ground responses in quotes**: For long document tasks, ask Claude to quote relevant parts of the documents first before carrying out its task. This helps Claude cut through the "noise" of the rest of the document's contents.
+
+  <Accordion title="Example quote extraction">
+    ```xml
+    You are an AI physician's assistant. Your task is to help doctors diagnose possible patient illnesses.
+
+    <documents>
+      <document index="1">
+        <source>patient_symptoms.txt</source>
+        <document_content>
+          {{PATIENT_SYMPTOMS}}
+        </document_content>
+      </document>
+      <document index="2">
+        <source>patient_records.txt</source>
+        <document_content>
+          {{PATIENT_RECORDS}}
+        </document_content>
+      </document>
+      <document index="3">
+        <source>patient01_appt_history.txt</source>
+        <document_content>
+          {{PATIENT01_APPOINTMENT_HISTORY}}
+        </document_content>
+      </document>
+    </documents>
+
+  Find quotes from the patient records and appointment history that are relevant to diagnosing the patient's reported symptoms. Place these in <quotes> tags. Then, based on these quotes, list all information that would help the doctor diagnose the patient's symptoms. Place your diagnostic information in <info> tags.
+
+  ```
+  </Accordion>
+  ```
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Prompt library" icon="link" href="/en/prompt-library/library">
+    Get inspired by a curated selection of prompts for various tasks and use cases.
+  </Card>
+
+  <Card title="GitHub prompting tutorial" icon="link" href="https://github.com/anthropics/prompt-eng-interactive-tutorial">
+    An example-filled tutorial that covers the prompt engineering concepts found in our docs.
+  </Card>
+
+  <Card title="Google Sheets prompting tutorial" icon="link" href="https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8">
+    A lighter weight version of our prompt engineering tutorial via an interactive spreadsheet.
+  </Card>
+</CardGroup>
+
+### 9. Extended Thinking Tips
+
+export const TryInConsoleButton = ({userPrompt, systemPrompt, maxTokens, thinkingBudgetTokens, buttonVariant = "primary", children}) => {
+const url = new URL("https://console.anthropic.com/workbench/new");
+if (userPrompt) {
+url.searchParams.set("user", userPrompt);
+}
+if (systemPrompt) {
+url.searchParams.set("system", systemPrompt);
+}
+if (maxTokens) {
+url.searchParams.set("max_tokens", maxTokens);
+}
+if (thinkingBudgetTokens) {
+url.searchParams.set("thinking.budget_tokens", thinkingBudgetTokens);
+}
+return <a href={url.href} className={`btn size-xs ${buttonVariant}`} style={{
+    margin: "-0.25rem -0.5rem"
+  }}>
+{children || "Try in Console"}{" "}
+<Icon icon="arrow-right" color="currentColor" size={14} />
+</a>;
+};
+
+This guide provides advanced strategies and techniques for getting the most out of Claude's extended thinking features. Extended thinking allows Claude to work through complex problems step-by-step, improving performance on difficult tasks.
+
+See [Extended thinking models](/en/docs/about-claude/models/extended-thinking-models) for guidance on deciding when to use extended thinking.
+
+#### Before diving in
+
+This guide presumes that you have already decided to use extended thinking mode and have reviewed our basic steps on [how to get started with extended thinking](/en/docs/about-claude/models/extended-thinking-models#getting-started-with-extended-thinking-models) as well as our [extended thinking implementation guide](/en/docs/build-with-claude/extended-thinking).
+
+##### Technical considerations for extended thinking
+
+- Thinking tokens have a minimum budget of 1024 tokens. We recommend that you start with the minimum thinking budget and incrementally increase to adjust based on your needs and task complexity.
+- For workloads where the optimal thinking budget is above 32K, we recommend that you use [batch processing](/en/docs/build-with-claude/batch-processing) to avoid networking issues. Requests pushing the model to think above 32K tokens causes long running requests that might run up against system timeouts and open connection limits.
+- Extended thinking performs best in English, though final outputs can be in [any language Claude supports](/en/docs/build-with-claude/multilingual-support).
+- If you need thinking below the minimum budget, we recommend using standard mode, with thinking turned off, with traditional chain-of-thought prompting with XML tags (like `<thinking>`). See [chain of thought prompting](/en/docs/build-with-claude/prompt-engineering/chain-of-thought).
+
+#### Prompting techniques for extended thinking
+
+##### Use general instructions first, then troubleshoot with more step-by-step instructions
+
+Claude often performs better with high level instructions to just think deeply about a task rather than step-by-step prescriptive guidance. The model's creativity in approaching problems may exceed a human's ability to prescribe the optimal thinking process.
+
+For example, instead of:
+
+<CodeGroup>
+  ```text User
+  Think through this math problem step by step: 
+  1. First, identify the variables
+  2. Then, set up the equation
+  3. Next, solve for x
+  ...
+  ```
+</CodeGroup>
+
+Consider:
+
+<CodeGroup>
+  ```text User
+  Please think about this math problem thoroughly and in great detail. 
+  Consider multiple approaches and show your complete reasoning.
+  Try different methods if your first approach doesn't work.
+  ```
+
+<CodeBlock
+filename={
+<TryInConsoleButton
+userPrompt={
+`Please think about this math problem thoroughly and in great detail. 
+Consider multiple approaches and show your complete reasoning.
+Try different methods if your first approach doesn't work.`
+}
+thinkingBudgetTokens={16000}
+
+>
+
+    Try in Console
+
+  </TryInConsoleButton>
+}
+  />
+</CodeGroup>
+
+That said, Claude can still effectively follow complex structured execution steps when needed. The model can handle even longer lists with more complex instructions than previous versions. We recommend that you start with more generalized instructions, then read Claude's thinking output and iterate to provide more specific instructions to steer its thinking from there.
+
+##### Multishot prompting with extended thinking
+
+[Multishot prompting](/en/docs/build-with-claude/prompt-engineering/multishot-prompting) works well with extended thinking. When you provide Claude examples of how to think through problems, it will follow similar reasoning patterns within its extended thinking blocks.
+
+You can include few-shot examples in your prompt in extended thinking scenarios by using XML tags like `<thinking>` or `<scratchpad>` to indicate canonical patterns of extended thinking in those examples.
+
+Claude will generalize the pattern to the formal extended thinking process. However, it's possible you'll get better results by giving Claude free rein to think in the way it deems best.
+
+Example:
+
+<CodeGroup>
+  ```text User
+  I'm going to show you how to solve a math problem, then I want you to solve a similar one.
+
+Problem 1: What is 15% of 80?
+
+  <thinking>
+  To find 15% of 80:
+  1. Convert 15% to a decimal: 15% = 0.15
+  2. Multiply: 0.15 × 80 = 12
+  </thinking>
+
+The answer is 12.
+
+Now solve this one:
+Problem 2: What is 35% of 240?
+
+````
+
+<CodeBlock
+  filename={
+<TryInConsoleButton
+  userPrompt={
+    `I'm going to show you how to solve a math problem, then I want you to solve a similar one.
+
+Problem 1: What is 15% of 80?
+
+<thinking>
+To find 15% of 80:
+1. Convert 15% to a decimal: 15% = 0.15
+2. Multiply: 0.15 × 80 = 12
+</thinking>
+
+The answer is 12.
+
+Now solve this one:
+Problem 2: What is 35% of 240?`
+  }
+  thinkingBudgetTokens={16000}
+>
+  Try in Console
+</TryInConsoleButton>
+}
+/>
+</CodeGroup>
+
+##### Maximizing instruction following with extended thinking
+
+Claude shows significantly improved instruction following when extended thinking is enabled. The model typically:
+
+1. Reasons about instructions inside the extended thinking block
+2. Executes those instructions in the response
+
+To maximize instruction following:
+
+* Be clear and specific about what you want
+* For complex instructions, consider breaking them into numbered steps that Claude should work through methodically
+* Allow Claude enough budget to process the instructions fully in its extended thinking
+
+##### Using extended thinking to debug and steer Claude's behavior
+
+You can use Claude's thinking output to debug Claude's logic, although this method is not always perfectly reliable.
+
+To make the best use of this methodology, we recommend the following tips:
+
+* We don't recommend passing Claude's extended thinking back in the user text block, as this doesn't improve performance and may actually degrade results.
+* Prefilling extended thinking is explicitly not allowed, and manually changing the model's output text that follows its thinking block is likely going to degrade results due to model confusion.
+
+When extended thinking is turned off, standard `assistant` response text [prefill](/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response) is still allowed.
+
+<Note>
+Sometimes Claude may repeat its extended thinking in the assistant output text. If you want a clean response, instruct Claude not to repeat its extended thinking and to only output the answer.
+</Note>
+
+##### Making the best of long outputs and longform thinking
+
+For dataset generation use cases, try prompts such as "Please create an extremely detailed table of..." for generating comprehensive datasets.
+
+For use cases such as detailed content generation where you may want to generate longer extended thinking blocks and more detailed responses, try these tips:
+
+* Increase both the maximum extended thinking length AND explicitly ask for longer outputs
+* For very long outputs (20,000+ words), request a detailed outline with word counts down to the paragraph level. Then ask Claude to index its paragraphs to the outline and maintain the specified word counts
+
+<Warning>
+We do not recommend that you push Claude to output more tokens for outputting tokens' sake. Rather, we encourage you to start with a small thinking budget and increase as needed to find the optimal settings for your use case.
+</Warning>
+
+Here are example use cases where Claude excels due to longer extended thinking:
+
+<AccordionGroup>
+<Accordion title="Complex STEM problems">
+  Complex STEM problems require Claude to build mental models, apply specialized knowledge, and work through sequential logical steps—processes that benefit from longer reasoning time.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Write a python script for a bouncing yellow ball within a square,
+        make sure to handle collision detection properly.
+        Make the square slowly rotate.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Write a python script for a bouncing yellow ball within a square,
+make sure to handle collision detection properly.
+Make the square slowly rotate.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This simpler task typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Write a Python script for a bouncing yellow ball within a tesseract,
+        making sure to handle collision detection properly.
+        Make the tesseract slowly rotate.
+        Make sure the ball stays within the tesseract.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Write a Python script for a bouncing yellow ball within a tesseract,
+making sure to handle collision detection properly.
+Make the tesseract slowly rotate.
+Make sure the ball stays within the tesseract.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This complex 4D visualization challenge makes the best use of long extended thinking time as Claude works through the mathematical and programming complexity.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+
+<Accordion title="Constraint optimization problems">
+  Constraint optimization challenges Claude to satisfy multiple competing requirements simultaneously, which is best accomplished when allowing for long extended thinking time so that the model can methodically address each constraint.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Plan a week-long vacation to Japan.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt="Plan a week-long vacation to Japan."
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This open-ended request typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Plan a 7-day trip to Japan with the following constraints:
+        - Budget of $2,500
+        - Must include Tokyo and Kyoto
+        - Need to accommodate a vegetarian diet
+        - Preference for cultural experiences over shopping
+        - Must include one day of hiking
+        - No more than 2 hours of travel between locations per day
+        - Need free time each afternoon for calls back home
+        - Must avoid crowds where possible
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Plan a 7-day trip to Japan with the following constraints:
+- Budget of $2,500
+- Must include Tokyo and Kyoto
+- Need to accommodate a vegetarian diet
+- Preference for cultural experiences over shopping
+- Must include one day of hiking
+- No more than 2 hours of travel between locations per day
+- Need free time each afternoon for calls back home
+- Must avoid crowds where possible`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        With multiple constraints to balance, Claude will naturally perform best when given more space to think through how to satisfy all requirements optimally.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+
+<Accordion title="Thinking frameworks">
+  Structured thinking frameworks give Claude an explicit methodology to follow, which may work best when Claude is given long extended thinking space to follow each step.
+
+  <Tabs>
+    <Tab title="Standard prompt">
+      <CodeGroup>
+        ```text User
+        Develop a comprehensive strategy for Microsoft
+        entering the personalized medicine market by 2027.
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Develop a comprehensive strategy for Microsoft
+entering the personalized medicine market by 2027.`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        This broad strategic question typically results in only about a few seconds of thinking time.
+      </Note>
+    </Tab>
+
+    <Tab title="Enhanced prompt">
+      <CodeGroup>
+        ```text User
+        Develop a comprehensive strategy for Microsoft entering
+        the personalized medicine market by 2027.
+
+        Begin with:
+        1. A Blue Ocean Strategy canvas
+        2. Apply Porter's Five Forces to identify competitive pressures
+
+        Next, conduct a scenario planning exercise with four
+        distinct futures based on regulatory and technological variables.
+
+        For each scenario:
+        - Develop strategic responses using the Ansoff Matrix
+
+        Finally, apply the Three Horizons framework to:
+        - Map the transition pathway
+        - Identify potential disruptive innovations at each stage
+        ```
+
+        <CodeBlock
+          filename={
+        <TryInConsoleButton
+          userPrompt={
+            `Develop a comprehensive strategy for Microsoft entering
+the personalized medicine market by 2027.
+
+Begin with:
+1. A Blue Ocean Strategy canvas
+2. Apply Porter's Five Forces to identify competitive pressures
+
+Next, conduct a scenario planning exercise with four
+distinct futures based on regulatory and technological variables.
+
+For each scenario:
+- Develop strategic responses using the Ansoff Matrix
+
+Finally, apply the Three Horizons framework to:
+- Map the transition pathway
+- Identify potential disruptive innovations at each stage`
+          }
+          thinkingBudgetTokens={16000}
+        >
+          Try in Console
+        </TryInConsoleButton>
+      }
+        />
+      </CodeGroup>
+
+      <Note>
+        By specifying multiple analytical frameworks that must be applied sequentially, thinking time naturally increases as Claude works through each framework methodically.
+      </Note>
+    </Tab>
+  </Tabs>
+</Accordion>
+</AccordionGroup>
+
+##### Have Claude reflect on and check its work for improved consistency and error handling
+
+You can use simple natural language prompting to improve consistency and reduce errors:
+
+1. Ask Claude to verify its work with a simple test before declaring a task complete
+2. Instruct the model to analyze whether its previous step achieved the expected result
+3. For coding tasks, ask Claude to run through test cases in its extended thinking
+
+Example:
+
+<CodeGroup>
+```text User
+Write a function to calculate the factorial of a number.
+Before you finish, please verify your solution with test cases for:
+- n=0
+- n=1
+- n=5
+- n=10
+And fix any issues you find.
+````
+
+<CodeBlock
+filename={
+<TryInConsoleButton
+userPrompt={
+`Write a function to calculate the factorial of a number.
+Before you finish, please verify your solution with test cases for:
+
+- n=0
+- n=1
+- n=5
+- n=10
+  And fix any issues you find.`
+  }
+  thinkingBudgetTokens={16000}
+  >
+      Try in Console
+    </TryInConsoleButton>
+  }
+    />
+  </CodeGroup>
+
+#### Next steps
+
+<CardGroup>
+  <Card title="Extended thinking cookbook" icon="book" href="https://github.com/anthropics/anthropic-cookbook/tree/main/extended_thinking">
+    Explore practical examples of extended thinking in our cookbook.
+  </Card>
+
+  <Card title="Extended thinking guide" icon="code" href="/en/docs/build-with-claude/extended-thinking">
+    See complete technical documentation for implementing extended thinking.
+  </Card>
+</CardGroup>
+
+### Claude 4 Best Practices
+
+Claude 4 models (Opus 4 and Sonnet 4) have been trained for more precise instruction following than previous generations.
+
+### General Principles
+
+#### Be explicit with your instructions
+
+Claude 4 models respond well to clear, explicit instructions. Being specific about your desired output can help enhance results. Customers who desire the "above and beyond" behavior from previous Claude models might need to more explicitly request these behaviors with Claude 4.
+
+<Accordion title="Example: Creating an analytics dashboard">
+  **Less effective:**
+
+```text
+Create an analytics dashboard
+```
+
+**More effective:**
+
+```text
+Create an analytics dashboard. Include as many relevant features and interactions as possible. Go beyond the basics to create a fully-featured implementation.
+```
+
+</Accordion>
+
+#### Add context to improve performance
+
+Providing context or motivation behind your instructions, such as explaining to Claude why such behavior is important, can help Claude 4 better understand your goals and deliver more targeted responses.
+
+<Accordion title="Example: Formatting preferences">
+  **Less effective:**
+
+```text
+NEVER use ellipses
+```
+
+**More effective:**
+
+```text
+Your response will be read aloud by a text-to-speech engine, so never use ellipses since the text-to-speech engine will not know how to pronounce them.
+```
+
+</Accordion>
+
+Claude is smart enough to generalize from the explanation.
+
+#### Be vigilant with examples & details
+
+Claude 4 models pay attention to details and examples as part of instruction following. Ensure that your examples align with the behaviors you want to encourage and minimize behaviors you want to avoid.
+
+### Guidance for Specific Situations
+
+#### Control the format of responses
+
+There are a few ways that we have found to be particularly effective in steering output formatting in Claude 4 models:
+
+1. **Tell Claude what to do instead of what not to do**
+
+   - Instead of: "Do not use markdown in your response"
+   - Try: "Your response should be composed of smoothly flowing prose paragraphs."
+
+2. **Use XML format indicators**
+
+   - Try: "Write the prose sections of your response in \<smoothly_flowing_prose_paragraphs> tags."
+
+3. **Match your prompt style to the desired output**
+
+   The formatting style used in your prompt may influence Claude's response style. If you are still experiencing steerability issues with output formatting, we recommend as best as you can matching your prompt style to your desired output style. For example, removing markdown from your prompt can reduce the volume of markdown in the output.
+
+#### Leverage thinking & interleaved thinking capabilities
+
+Claude 4 offers thinking capabilities that can be especially helpful for tasks involving reflection after tool use or complex multi-step reasoning. You can guide its initial or interleaved thinking for better results.
+
+```text Example prompt
+After receiving tool results, carefully reflect on their quality and determine optimal next steps before proceeding. Use your thinking to plan and iterate based on this new information, and then take the best next action.
+```
+
+<Info>
+  For more information on thinking capabilities, see [Extended thinking](/en/docs/build-with-claude/extended-thinking).
+</Info>
+
+#### Optimize parallel tool calling
+
+Claude 4 models excel at parallel tool execution. They have a high success rate in using parallel tool calling without any prompting to do so, but some minor prompting can boost this behavior to \~100% parallel tool use success rate. We have found this prompt to be most effective:
+
+```text Sample prompt for agents
+For maximum efficiency, whenever you need to perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially.
+```
+
+#### Reduce file creation in agentic coding
+
+Claude 4 models may sometimes create new files for testing and iteration purposes, particularly when working with code. This approach allows Claude to use files, especially python scripts, as a 'temporary scratchpad' before saving its final output. Using temporary files can improve outcomes particularly for agentic coding use cases.
+
+If you'd prefer to minimize net new file creation, you can instruct Claude to clean up after itself:
+
+```text Sample prompt
+If you create any temporary new files, scripts, or helper files for iteration, clean up these files by removing them at the end of the task.
+```
+
+#### Enhance visual and frontend code generation
+
+For frontend code generation, you can steer Claude 4 models to create complex, detailed, and interactive designs by providing explicit encouragement:
+
+```text Sample prompt
+Don't hold back. Give it your all.
+```
+
+You can also improve Claude's frontend performance in specific areas by providing additional modifiers and details on what to focus on:
+
+- "Include as many relevant features and interactions as possible"
+- "Add thoughtful details like hover states, transitions, and micro-interactions"
+- "Create an impressive demonstration showcasing web development capabilities"
+- "Apply design principles: hierarchy, contrast, balance, and movement"
+
+### Migration Considerations
+
+When migrating from Sonnet 3.7 to Claude 4:
+
+1. **Be specific about desired behavior**: Consider describing exactly what you'd like to see in the output.
+
+2. **Frame your instructions with modifiers**: Adding modifiers that encourage Claude to increase the quality and detail of its output can help better shape Claude's performance. For example, instead of "Create an analytics dashboard", use "Create an analytics dashboard. Include as many relevant features and interactions as possible. Go beyond the basics to create a fully-featured implementation."
+
+3. **Request specific features explicitly**: Animations and interactive elements should be requested explicitly when desired.
+
+#### Model Personalities & Distillation Strategy
+
+Different LLMs have distinct "personalities" and capabilities. Understanding these can help you optimize your prompts:
+
+**Claude Characteristics:**
+- More conversational and human-like in responses
+- Strong at following complex instructions and reasoning
+- Excels at ethical reasoning and nuanced analysis
+- Generally requires less explicit steering than other models
+
+**Cross-Model Considerations:**
+- **Llama models** might need more explicit steering and structure
+- **GPT models** may have different formatting preferences
+- **Smaller models** often benefit from more specific instructions
+
+**Distillation Strategy:**
+1. **Develop with larger models:** Use Claude 4 or other capable models for complex meta-prompting and refinement
+2. **Test across models:** Validate prompts work across your target model types
+3. **Distill for production:** Adapt optimized prompts for smaller, faster, or cheaper models
+4. **Maintain quality:** Use evaluation suites to ensure performance doesn't degrade
+
+This approach optimizes for both quality (from larger models) and cost/latency (with smaller models).
+
+## Evaluation: Your Crown Jewels
+
+While prompts are important, your evaluation suite (the set of test cases to measure prompt quality and performance) is often your most valuable intellectual property. Leading AI startups consider evals their secret weapon.
+
+### Why Evaluations Matter
+
+- **Objective measurement:** Know definitively whether a prompt change improves or degrades performance  
+- **Iterative improvement:** Essential for knowing why a prompt works and for iterating effectively
+- **Quality assurance:** Prevent regressions when updating prompts or switching models
+- **Benchmarking:** Compare performance across different models or prompt variations
+
+### Building Effective Evaluation Suites
+
+1. **Diverse test cases:** Cover edge cases, typical scenarios, and failure modes
+2. **Clear success criteria:** Define what "good" output looks like for each test case
+3. **Automated scoring:** Where possible, use automated metrics (accuracy, format compliance, etc.)
+4. **Human evaluation:** Include human judgment for nuanced tasks like tone, creativity, or ethical reasoning
+5. **Representative data:** Use real-world data that matches your production use cases
+
+### Evaluation-Driven Development
+
+```
+1. Define success metrics for your task
+2. Create comprehensive test cases  
+3. Baseline current prompt performance
+4. Iterate on prompts using meta-prompting and other techniques
+5. Run evaluations to measure improvement
+6. Deploy only changes that improve eval scores
+```
+
+**Pro tip:** Start building your evaluation suite early, even before perfecting your prompts. The insights from systematic evaluation often reveal prompt improvement opportunities you wouldn't have discovered otherwise.
+
+### Claude Code Workflows
+
+#### Give Claude more tools
+
+Claude has access to your shell environment, where you can build up sets of convenience scripts and functions for it just like you would for yourself. It can also leverage more complex tools through MCP and REST APIs.
+
+#### a. Use Claude with bash tools
+
+Claude Code inherits your bash environment, giving it access to all your tools. While Claude knows common utilities like unix tools and gh, it won't know about your custom bash tools without instructions:
+
+- Tell Claude the tool name with usage examples
+- Tell Claude to run --help to see tool documentation
+- Document frequently used tools in CLAUDE.md
+
+#### Recommended Workflows
+
+**Research, Plan, Implement**
+
+1. Ask Claude to read relevant files, images, or URLs, providing either general pointers ("read the file that handles logging") or specific filenames ("read logging.py"), but explicitly tell it not to write any code just yet.
+2. This is the part of the workflow where you should consider strong use of subagents, especially for complex problems. Telling Claude to use subagents to verify details or investigate particular questions it might have, especially early on in a conversation or task, tends to preserve context availability without much downside in terms of lost efficiency.
+3. Ask Claude to make a plan for how to approach a specific problem. We recommend using the word "think" to trigger extended thinking mode, which gives Claude additional computation time to evaluate alternatives more thoroughly. These specific phrases are mapped directly to increasing levels of thinking budget in the system: "think" < "think hard" < "think harder" < "ultrathink." Each level allocates progressively more thinking budget for Claude to use.
+4. If the results of this step seem reasonable, you can have Claude create a document or a GitHub issue with its plan so that you can reset to this spot if the implementation (step 3) isn't what you want.
+5. Ask Claude to implement its solution in code. This is also a good place to ask it to explicitly verify the reasonableness of its solution as it implements pieces of the solution.
+6. Ask Claude to commit the result and create a pull request. If relevant, this is also a good time to have Claude update any READMEs or changelogs with an explanation of what it just did.
+
+Steps #1-#2 are crucial—without them, Claude tends to jump straight to coding a solution. While sometimes that's what you want, asking Claude to research and plan first significantly improves performance for problems requiring deeper thinking upfront.
+
+**Write tests, commit; code, iterate, commit**
+
+This is an Anthropic-favorite workflow for changes that are easily verifiable with unit, integration, or end-to-end tests. Test-driven development (TDD) becomes even more powerful with agentic coding:
+
+1. Ask Claude to write tests based on expected input/output pairs. Be explicit about the fact that you're doing test-driven development so that it avoids creating mock implementations, even for functionality that doesn't exist yet in the codebase.
+2. Tell Claude to run the tests and confirm they fail. Explicitly telling it not to write any implementation code at this stage is often helpful.
+3. Ask Claude to commit the tests when you're satisfied with them.
+4. Ask Claude to write code that passes the tests, instructing it not to modify the tests. Tell Claude to keep going until all tests pass. It will usually take a few iterations for Claude to write code, run the tests, adjust the code, and run the tests again.
+5. At this stage, it can help to ask it to verify with independent subagents that the implementation isn't overfitting to the tests
+6. Ask Claude to commit the code once you're satisfied with the changes.
+
+Claude performs best when it has a clear target to iterate against—a visual mock, a test case, or another kind of output. By providing expected outputs like tests, Claude can make changes, evaluate results, and incrementally improve until it succeeds.
+
+**Write code, screenshot result, iterate**
+
+Similar to the testing workflow, you can provide Claude with visual targets:
+
+1. Give Claude a way to take browser screenshots (e.g., with the Puppeteer MCP server, an iOS simulator MCP server, or manually copy / paste screenshots into Claude).
+2. Give Claude a visual mock by copying / pasting or drag-dropping an image, or giving Claude the image file path.
+3. Ask Claude to implement the design in code, take screenshots of the result, and iterate until its result matches the mock.
+4. Ask Claude to commit when you're satisfied.
+
+Like humans, Claude's outputs tend to improve significantly with iteration. While the first version might be good, after 2-3 iterations it will typically look much better. Give Claude the tools to see its outputs for best results.
+
+**Use Claude to interact with git**
+
+Claude can effectively handle many git operations. Many Anthropic engineers use Claude for 90%+ of our git interactions:
+
+- Searching git history to answer questions like "What changes made it into v1.2.3?", "Who owns this particular feature?", or "Why was this API designed this way?" It helps to explicitly prompt Claude to look through git history to answer queries like these.
+- Writing commit messages. Claude will look at your changes and recent history automatically to compose a message taking all the relevant context into account
+- Handling complex git operations like reverting files, resolving rebase conflicts, and comparing and grafting patches
+
+**Use Claude to interact with GitHub**
+
+Claude Code can manage many GitHub interactions:
+
+- Creating pull requests: Claude understands the shorthand "pr" and will generate appropriate commit messages based on the diff and surrounding context.
+- Implementing one-shot resolutions for simple code review comments: just tell it to fix comments on your PR (optionally, give it more specific instructions) and push back to the PR branch when it's done.
+- Fixing failing builds or linter warnings
+- Categorizing and triaging open issues by asking Claude to loop over open GitHub issues
+
+This eliminates the need to remember gh command line syntax while automating routine tasks.
+
+**Use Claude to work with Jupyter notebooks**
+
+Researchers and data scientists at Anthropic use Claude Code to read and write Jupyter notebooks. Claude can interpret outputs, including images, providing a fast way to explore and interact with data. There are no required prompts or workflows, but a workflow we recommend is to have Claude Code and a .ipynb file open side-by-side in VS Code.
+
+You can also ask Claude to clean up or make aesthetic improvements to your Jupyter notebook before you show it to colleagues. Specifically telling it to make the notebook or its data visualizations "aesthetically pleasing" tends to help remind it that it's optimizing for a human viewing experience.
+
+#### Optimize Your Workflow
+
+The suggestions below apply across all workflows:
+
+**Be specific in your instructions**
+
+Claude Code's success rate improves significantly with more specific instructions, especially on first attempts. Giving clear directions upfront reduces the need for course corrections later.
+
+For example:
+
+| Poor                                             | Good                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| add tests for foo.py                             | write a new test case for foo.py, covering the edge case where the user is logged out. avoid mocks                                                                                                                                                                                                                                                                                                                                                      |
+| why does ExecutionFactory have such a weird api? | look through ExecutionFactory's git history and summarize how its api came to be                                                                                                                                                                                                                                                                                                                                                                        |
+| add a calendar widget                            | look at how existing widgets are implemented on the home page to understand the patterns and specifically how code and interfaces are separated out. HotDogWidget.php is a good example to start with. then, follow the pattern to implement a new calendar widget that lets the user select a month and paginate forwards/backwards to pick a year. Build from scratch without libraries other than the ones already used in the rest of the codebase. |
+
+Claude can infer intent, but it can't read minds. Specificity leads to better alignment with expectations.
+
+**Give Claude images**
+
+Claude excels with images and diagrams through several methods:
+
+- Paste screenshots (pro tip: hit cmd+ctrl+shift+4 in macOS to screenshot to clipboard and ctrl+v to paste. Note that this is not cmd+v like you would usually use to paste on mac and does not work remotely.)
+- Drag and drop images directly into the prompt input
+- Provide file paths for images
+
+This is particularly useful when working with design mocks as reference points for UI development, and visual charts for analysis and debugging. If you are not adding visuals to context, it can still be helpful to be clear with Claude about how important it is for the result to be visually appealing.
+
+**Mention files you want Claude to look at or work on**
+
+Use tab-completion to quickly reference files or folders anywhere in your repository, helping Claude find or update the right resources.
+
+**Give Claude URLs**
+
+Paste specific URLs alongside your prompts for Claude to fetch and read. To avoid permission prompts for the same domains (e.g., docs.foo.com), use /allowed-tools to add domains to your allowlist.
+
+**Course correct early and often**
+
+While auto-accept mode (shift+tab to toggle) lets Claude work autonomously, you'll typically get better results by being an active collaborator and guiding Claude's approach. You can get the best results by thoroughly explaining the task to Claude at the beginning, but you can also course correct Claude at any time.
+
+These four tools help with course correction:
+
+1. Ask Claude to make a plan before coding. Explicitly tell it not to code until you've confirmed its plan looks good.
+2. Press Escape to interrupt Claude during any phase (thinking, tool calls, file edits), preserving context so you can redirect or expand instructions.
+3. Double-tap Escape to jump back in history, edit a previous prompt, and explore a different direction. You can edit the prompt and repeat until you get the result you're looking for.
+4. Ask Claude to undo changes, often in conjunction with option #2 to take a different approach.
+
+Though Claude Code occasionally solves problems perfectly on the first attempt, using these correction tools generally produces better solutions faster.
+
+**Use /clear to keep context focused**
+
+During long sessions, Claude's context window can fill with irrelevant conversation, file contents, and commands. This can reduce performance and sometimes distract Claude. Use the /clear command frequently between tasks to reset the context window.
+
+**Use checklists and scratchpads for complex workflows**
+
+For large tasks with multiple steps or requiring exhaustive solutions—like code migrations, fixing numerous lint errors, or running complex build scripts—improve performance by having Claude use a Markdown file (or even a GitHub issue!) as a checklist and working scratchpad:
+
+For example, to fix a large number of lint issues, you can do the following:
+
+1. Tell Claude to run the lint command and write all resulting errors (with filenames and line numbers) to a Markdown checklist
+2. Instruct Claude to address each issue one by one, fixing and verifying before checking it off and moving to the next
+
+**Pass data into Claude**
+
+Several methods exist for providing data to Claude:
+
+- Copy and paste directly into your prompt (most common approach)
+- Pipe into Claude Code (e.g., cat foo.txt | claude), particularly useful for logs, CSVs, and large data
+- Tell Claude to pull data via bash commands, MCP tools, or custom slash commands
+- Ask Claude to read files or fetch URLs (works for images too)
+
+Most sessions involve a combination of these approaches. For example, you can pipe in a log file, then tell Claude to use a tool to pull in additional context to debug the logs.

--- a/.claude/commands/agents/AGENT-playbook-to-automated-agent-workflow.md
+++ b/.claude/commands/agents/AGENT-playbook-to-automated-agent-workflow.md
@@ -1,0 +1,96 @@
+# Convert Manual Playbook to Automated Agent Workflow
+
+You are a workflow automation specialist who transforms human-oriented documentation into precise, actionable instructions for AI agents. Your expertise is in creating deterministic, repeatable processes that work reliably in automated environments.
+
+## Task
+
+Transform the following manual playbook into agent-executable instructions (leave the original file and create a copy of the transformed file in nearby directory called something similar to "agent-workflows" -- create it if it doesn't exist):
+
+<manual_playbook>
+$ARGUMENTS
+</manual_playbook>
+
+## Instructions
+
+Follow these steps to create automated agent instructions:
+
+### 1. Analysis Phase
+- Identify all vague references (e.g., "use a database", "check logs")  
+- Note any time-based conditions that need automation logic
+- Find assumptions about human judgment or context
+- List any undefined file paths, tools, or systems
+
+### 2. Specification Phase
+For each vague element, provide:
+- **Exact file paths** (e.g., `/data/reports/hashtag_analysis.json`)
+- **Specific tool commands** (e.g., `grep "ERROR" /var/log/app.log`)
+- **Conditional logic** for file existence and timing checks
+- **Explicit decision criteria** replacing human judgment
+
+### 3. State-Aware Design
+Assume the agent may run this workflow multiple times. For each instruction:
+- Handle cases where files may or may not exist
+- Include timestamp/date checking logic where relevant
+- Provide clear success/failure criteria
+- Specify what to do if prerequisites are missing
+
+### 4. Output Format
+Structure your response as:
+
+<automated_workflow>
+**Objective:** [Clear statement of what this workflow accomplishes]
+
+**Prerequisites:** 
+- [List any required files, tools, or system states]
+
+**Instructions:**
+1. [Step-by-step instructions with specific commands/file paths]
+2. [Include conditional logic: "If X exists, then Y, otherwise Z"]
+3. [Time-based checks: "If last run was more than N days ago..."]
+
+**Verification:**
+- [How to confirm the workflow completed successfully]
+- [What outputs/files should exist after completion]
+
+**Error Handling:**
+- [What to do if key files are missing]
+- [How to handle common failure scenarios]
+</automated_workflow>
+
+## Examples
+
+<example>
+**Before (Manual):** "Weekly hashtag reporting: review social media performance"
+
+**After (Automated):** 
+```
+1. Check file `/reports/hashtag_analysis.json` for last run date
+2. If no file exists OR last run was >7 days ago:
+   a. Execute: `python scripts/social_analytics.py --export /reports/hashtag_analysis.json`
+   b. Generate summary: `python scripts/summarize_hashtags.py /reports/hashtag_analysis.json > /reports/weekly_hashtag_summary.md`
+3. If file exists and last run was <7 days ago: skip processing
+```
+</example>
+
+<example>
+**Before (Manual):** "Use database or logs to check system health"
+
+**After (Automated):**
+```
+1. Check system database: `mysql -e "SELECT COUNT(*) FROM active_connections" monitoring_db`
+2. If database unavailable, fallback to log analysis: `tail -100 /var/log/system.log | grep -c "ERROR"`
+3. If error count >10: create alert file `/alerts/system_health_warning.txt` with timestamp
+```
+</example>
+
+## Quality Criteria
+
+Your automated workflow must be:
+- **Deterministic:** Same inputs always produce same outputs
+- **Self-contained:** No undefined file paths or tools
+- **Resilient:** Handles missing files and edge cases gracefully  
+- **Verifiable:** Clear success/failure indicators
+
+If any part of the manual playbook cannot be automated without additional context, explicitly state: "REQUIRES CLARIFICATION:" followed by specific questions about the unclear elements.
+
+Never make assumptions about file locations, tool availability, or system configuration that aren't specified in the original playbook.

--- a/.claude/commands/analysis/ANALYZE-repo-for-claude.md
+++ b/.claude/commands/analysis/ANALYZE-repo-for-claude.md
@@ -1,0 +1,140 @@
+# ANALYZE Repository for Claude
+
+Your task is to create a comprehensive repository analysis guide optimized for Claude Code to understand how the repository works. This guide will serve as documentation that helps AI agents quickly get up-to-speed on the codebase.
+
+## Storage System
+
+All repository summaries are stored in `~/project-summaries-for-agents/`:
+- `filepath-mapping.json`: Maps repository file paths to summary folder names
+- Individual folders contain the actual summary files for each repository
+
+## Process Overview
+
+1. **Check for existing summary**: Before starting, check if a summary already exists for this repository path
+2. **If exists**: Focus on IMPROVING the existing summary (shorter process)
+3. **If new**: Create a comprehensive new summary (full analysis process)
+
+## For Existing Summaries (Improvement Mode)
+
+When a summary already exists:
+1. Read the existing summary file
+2. Identify gaps, outdated information, or areas needing enhancement
+3. Update specific sections rather than rewriting everything
+4. Focus on recent changes, new patterns, or missed architectural details
+5. Keep the improvement process concise and targeted
+
+## For New Summaries (Full Analysis Mode)
+
+### Repository Analysis Methodology
+
+You should exhaust all available resources to understand the repository:
+
+#### 1. Check for DeepWiki Documentation
+- Visit https://deepwiki.com/[repo-owner]/[repo-name] to see if comprehensive documentation exists
+- Example: https://deepwiki.com/Comfy-Org/ComfyUI_frontend for the Comfy-Org/ComfyUI_frontend repo
+- Extract all available architectural and development information
+
+#### 2. Analyze Local Repository Structure
+- Examine the current working directory and identify key files
+- Check for CLAUDE.md files that contain development guidelines
+- Read README files at multiple levels (root, subdirectories)
+- Identify package.json, requirements.txt, or equivalent dependency files
+- Look for configuration files (vite.config, tsconfig.json, etc.)
+
+#### 3. Research Official Documentation
+- Use WebSearch to find official project documentation
+- Look for developer guides, API documentation, and architecture overviews
+- Check for contributing guidelines and development setup instructions
+
+#### 4. Examine Git History and Development Patterns
+- Use `git log --oneline -20` to understand recent development activity
+- Check `git status` and `git diff` to understand current state
+- Use GitHub CLI (`gh`) to examine recent PRs, issues, and releases
+- Identify commit message patterns and development workflow
+
+#### 5. Analyze Codebase Architecture
+- Identify main technologies, frameworks, and libraries used
+- Map out directory structure and file organization patterns
+- Understand build systems, testing frameworks, and development tools
+- Document core modules, services, and architectural patterns
+
+## Output Format
+
+Create a comprehensive markdown guide that includes:
+
+### Repository Overview
+- Purpose and main functionality
+- Repository ownership and links
+- Current version and license information
+
+### Technology Stack
+- Primary languages and frameworks
+- Key dependencies and their versions
+- Build tools and development environment
+
+### Directory Structure
+- Well-organized overview of folder hierarchy
+- Purpose of each major directory
+- Key files and their roles
+
+### Development Workflow
+- Essential commands for development, testing, and building
+- Code quality tools (linting, formatting, type checking)
+- Testing strategies and commands
+
+### Critical Development Guidelines
+- Coding standards and patterns to follow
+- API design principles
+- Git and PR guidelines
+- Important rules from CLAUDE.md files
+
+### Architecture & Patterns
+- Core architectural concepts
+- Extension/plugin systems
+- State management approaches
+- Communication patterns
+
+### Common Development Tasks
+- How to add new features
+- Testing procedures
+- Deployment processes
+- Troubleshooting guides
+
+## Meta-Optimization for Claude Code
+
+Remember that this guide will be consumed by AI agents, so:
+
+### Structure for AI Consumption
+- Use clear, hierarchical markdown formatting
+- Include specific file paths and line references where relevant
+- Provide concrete code examples and patterns
+- Use consistent terminology throughout
+
+### Action-Oriented Information
+- Focus on "how to do X" rather than just "what is X"
+- Include specific commands and their purposes
+- Highlight critical files that Claude should prioritize reading
+- Provide decision trees for common development scenarios
+
+### Context-Rich Details
+- Explain WHY certain patterns exist, not just WHAT they are
+- Include common pitfalls and how to avoid them
+- Document the relationship between different parts of the system
+- Explain the impact of changes on various components
+
+### Optimization for Different Use Cases
+- Separate beginner vs. advanced information clearly
+- Include both conceptual understanding and practical implementation
+- Provide templates and examples for common tasks
+- Link to relevant external documentation and resources
+
+## Quality Standards
+
+The final guide should:
+- Be comprehensive yet concise
+- Enable rapid onboarding for new contributors
+- Serve as a reliable reference for development decisions
+- Help AI agents understand the codebase's unique patterns and conventions
+- Provide actionable guidance for common development tasks
+
+Focus on creating a guide that maximizes the effectiveness of AI-assisted development while maintaining accuracy and completeness.

--- a/.claude/commands/github/GH-ISSUE-enhance-issue-description.md
+++ b/.claude/commands/github/GH-ISSUE-enhance-issue-description.md
@@ -1,0 +1,135 @@
+# Enhance GitHub Issue Documentation
+
+Your task is to research and analyze GitHub issue $ARGUMENTS, then suggest comprehensive improvements to make it more verbose, helpful, and well-documented according to best practices.
+
+## Research Phase
+
+First, thoroughly research the issue using ALL of the following methods:
+
+### 1. Read the Issue and Comments
+Use `gh issue view $ARGUMENTS --comments` to get the full issue details and all comments. Pay attention to:
+- The original problem description
+- Any clarifications in comments
+- Attempted solutions or workarounds mentioned
+- Related issues or PRs referenced
+
+### 2. Search Local Repositories
+Check these local Comfy-Org repositories if the issue is related to Comfy:
+- ~/projects/comfy-testing-environment/
+- ~/projects/comfyui-frontend-testing/
+
+Look for:
+- Related code that might be affected
+- Existing patterns or implementations
+- README files in relevant directories
+- Test files that might provide context
+
+### 3. Review Documentation
+- For Comfy-related issues, thoroughly review the docs at ~/projects/comfyui-frontend-testing/docs
+- Pay special attention to:
+  - Overview and architecture documentation
+  - API references
+  - Extension/mod development guides
+  - Any existing documentation about the feature/area in question
+
+### 4. Analyze Git History
+Research the commit history for relevant files:
+- Use `git log --grep` to find commits mentioning related keywords
+- Look at `git blame` for files mentioned in the issue
+- Check `git log --follow` for file history if files were renamed
+- Search for commits by the issue reporter to understand their context
+
+### 5. Find Related Issues and PRs
+- Use `gh issue list` and `gh pr list` with relevant search terms
+- Look for:
+  - Similar issues (open and closed)
+  - PRs that might have introduced the issue
+  - PRs attempting to fix similar problems
+  - Linked issues in the issue body or comments
+
+### 6. Web Research
+If needed, search for:
+- External documentation (PrimeVue, Electron, Vitest, Playwright, etc.)
+- Stack Overflow discussions about similar problems
+- Blog posts or tutorials covering the topic
+- Best practices for the specific technology/pattern
+
+### 7. Code Analysis
+- Search the codebase for usage patterns
+- Identify all files that might be affected
+- Look for existing tests that cover this area
+- Check for similar implementations elsewhere in the codebase
+
+## Enhancement Suggestions
+
+After completing your research, provide a comprehensive enhancement suggestion that includes:
+
+### 1. Enhanced Issue Title
+Suggest a more descriptive title that clearly indicates:
+- The component/area affected
+- The specific problem
+- The impact (if applicable)
+
+### 2. Structured Issue Description
+Create a well-organized issue description with these sections:
+
+#### Background/Context
+- Explain the broader context
+- Why this issue matters
+- How it fits into the overall system
+
+#### Problem Statement
+- Clear, detailed description of the issue
+- Current behavior vs expected behavior
+- Impact on users/developers
+
+#### Steps to Reproduce
+- Detailed, numbered steps
+- Include code snippets where relevant
+- Specify environment details
+
+#### Root Cause Analysis (if discovered)
+- Technical explanation of why this happens
+- Reference specific code locations
+- Link to relevant commits if applicable
+
+#### Proposed Solution(s)
+- Multiple approaches if applicable
+- Pros and cons of each approach
+- Recommended approach with justification
+
+#### Testing Considerations
+- How to verify the fix
+- What tests should be added
+- Edge cases to consider
+
+### 3. Supporting Materials
+Suggest adding:
+
+#### Code Examples
+- Before/after code snippets
+- Example implementations
+- Common patterns that could be followed
+
+#### Visual Aids
+- Diagrams explaining the architecture
+- Screenshots showing the issue
+- Flowcharts for complex processes
+
+#### References and Links
+- Links to related issues/PRs
+- Documentation references
+- External resources
+- Specific file paths and line numbers
+
+#### Implementation Checklist
+- Break down the fix into subtasks
+- Include both code changes and documentation updates
+- Testing requirements
+- Review considerations
+
+## Example Format
+
+Present your enhancement suggestion in a clear format that the user can easily copy and use to update the GitHub issue. Use markdown formatting and make it ready to paste.
+
+Remember: The goal is to transform a potentially vague or incomplete issue into a comprehensive, actionable document that serves as a complete reference for anyone working on the problem. Include all context discovered during research, making the issue self-contained and educational.

--- a/.claude/commands/github/GH-PR-add-review-comments-to-pr.md
+++ b/.claude/commands/github/GH-PR-add-review-comments-to-pr.md
@@ -1,0 +1,117 @@
+# PR Review Command
+
+You are a senior software engineer and code reviewer with expertise in software architecture, security, performance, and maintainability. Your reviews help maintain code quality and mentor team members through constructive feedback.
+
+## Task
+Review the pull request specified in $ARGUMENTS and provide comprehensive feedback that improves code quality while being constructive and educational.
+
+## Instructions
+
+<review_process>
+1. **Fetch PR details**: Use `gh pr view $ARGUMENTS` to get PR information, including:
+   - Title and description
+   - Changed files and diff
+   - Author and reviewers
+   - Related issues or discussions
+
+2. **Analyze the changes thoroughly**, focusing on:
+   - **Code quality**: Readability, maintainability, and adherence to best practices
+   - **Architecture**: Design patterns, separation of concerns, and system integration
+   - **Security**: Potential vulnerabilities, input validation, and access controls
+   - **Performance**: Efficiency, scalability concerns, and resource usage
+   - **Testing**: Test coverage, test quality, and edge cases
+   - **Documentation**: Code comments, README updates, and API documentation
+
+3. **Generate review suggestions** in the structured format below
+
+4. **Iterate with me** on the review comments until I'm satisfied
+
+5. **Submit the review** using GitHub CLI once approved
+</review_process>
+
+## Review Comment Structure
+
+Format your suggestions using this structure:
+
+<review_suggestions>
+<file_reviews>
+<!-- For each file with feedback -->
+<file name="path/to/file.ext">
+<line_comments>
+<!-- Specific line-by-line feedback -->
+<comment line="42" type="suggestion|issue|question|praise">
+**Issue**: Brief description of the concern
+**Impact**: Why this matters (security/performance/maintainability)
+**Suggestion**: Specific recommendation with example if helpful
+</comment>
+</line_comments>
+
+<general_feedback>
+<!-- File-level observations -->
+</general_feedback>
+</file>
+</file_reviews>
+
+<overall_assessment>
+<!-- PR-level feedback -->
+**Strengths**: What's done well
+**Concerns**: Major issues that need addressing
+**Recommendations**: High-level suggestions for improvement
+</overall_assessment>
+</review_suggestions>
+
+## Examples of Effective Review Comments
+
+<examples>
+<example type="security_issue">
+**Issue**: Potential SQL injection vulnerability
+**Impact**: Untrusted user input is directly interpolated into SQL query, allowing attackers to execute arbitrary database commands
+**Suggestion**: Use parameterized queries instead:
+```sql
+SELECT * FROM users WHERE id = ? AND status = ?
+```
+</example>
+
+<example type="performance_concern">
+**Issue**: N+1 query problem in loop
+**Impact**: This will execute one database query per item, causing performance degradation with large datasets
+**Suggestion**: Consider using a batch query or eager loading to fetch all required data in a single operation
+</example>
+
+<example type="code_quality">
+**Issue**: Complex conditional logic is hard to follow
+**Impact**: Reduces readability and increases maintenance burden
+**Suggestion**: Consider extracting this logic into a well-named helper method or using early returns to reduce nesting
+</example>
+
+<example type="positive_feedback">
+**Praise**: Excellent use of the builder pattern here - makes the API much more readable and flexible. The fluent interface really improves the developer experience.
+</example>
+</examples>
+
+## Context and Guidelines
+
+<context>
+This review will be submitted to GitHub where the author and team will see your feedback. Your comments should:
+- Be constructive and educational rather than just critical
+- Explain the "why" behind suggestions to help the author learn
+- Balance thoroughness with practicality
+- Recognize good practices as well as areas for improvement
+- Consider the broader codebase context and team standards
+</context>
+
+<guidelines>
+- If the PR is too large or complex to review effectively, suggest breaking it into smaller, focused PRs
+- If you need more context about requirements or design decisions, ask clarifying questions
+- Prioritize feedback: Mark critical security/correctness issues clearly vs. style preferences
+- Suggest specific improvements rather than just pointing out problems
+- If you cannot access the PR or lack sufficient information, say "I don't know" and ask for clarification
+</guidelines>
+
+## Next Steps
+
+1. I'll review your suggestions and provide feedback
+2. We'll iterate until the review comments are ready
+3. Once approved, I'll ask you to submit the review using `gh pr review $ARGUMENTS --body "review_text"`
+
+Please start by fetching and analyzing the PR: $ARGUMENTS

--- a/.claude/commands/github/GH-PR-analyze-status.md
+++ b/.claude/commands/github/GH-PR-analyze-status.md
@@ -1,0 +1,155 @@
+# PR Status Analysis Command
+
+You are an expert GitHub workflow analyst. Your task is to analyze all open pull requests by the current github username of my terminal session that are less than 3 months old and provide actionable completion summaries.
+
+## Instructions
+
+Follow these steps systematically:
+
+### 1. Data Collection Phase
+
+First, gather comprehensive PR data:
+
+```bash
+# Get all open PRs by christian-byrne from the last 3 months
+gh search prs --author=christian-byrne --state=open --created=">=`date -d '3 months ago' '+%Y-%m-%d'`" --json url,title,repository,number,createdAt,updatedAt,headRefName,baseRefName,mergeable,reviewDecision,assignees,labels,milestone --limit 100
+```
+
+For each PR found:
+
+1. **Get detailed PR information:**
+   ```bash
+   gh pr view <PR_URL> --json url,title,number,state,createdAt,updatedAt,headRefName,baseRefName,mergeable,reviewDecision,reviewRequests,assignees,labels,milestone,body,commits,files,additions,deletions
+   ```
+
+2. **Get PR comments and reviews:**
+   ```bash
+   gh pr view <PR_URL> --comments --json comments
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews
+   ```
+
+3. **Get linked issues:**
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/timeline | jq '.[] | select(.event == "cross-referenced") | .source.issue'
+   ```
+
+4. **Check local branch status:**
+   ```bash
+   # For each repository, check if we have local branches
+   git branch -a | grep <head_ref_name>
+   git status # if on the branch
+   git log --oneline origin/<base_branch>..<head_ref_name> # unpushed commits
+   ```
+
+### 2. Slack Integration (Optional)
+
+If Slack MCP is available, search for recent discussions about each PR:
+
+```bash
+# Search Slack for PR mentions
+mcp__slack__conversations_history --channel_id <relevant_channels> --limit "7d" | grep -i "<PR_title_keywords>"
+```
+
+### 3. Analysis and Synthesis
+
+For each PR, analyze:
+
+**Status Indicators:**
+- [ ] Review status (approved, changes requested, pending)
+- [ ] CI/CD status 
+- [ ] Merge conflicts
+- [ ] Linked issue completion status
+- [ ] Outstanding review comments
+- [ ] Branch sync status with base
+
+**Completion Blockers:**
+- [ ] Unresolved review feedback
+- [ ] Failing tests/CI
+- [ ] Missing documentation
+- [ ] Merge conflicts
+- [ ] Dependent issues/PRs
+- [ ] Required approvals
+
+### 4. Output Format
+
+Structure your response as follows:
+
+## PR Status Analysis Report
+
+### Summary
+*Brief overview of total PRs, repositories involved, and general status*
+
+### PR Analysis by Repository
+
+#### Repository: `[repo-name]`
+
+##### PR #[number]: [title]
+**Created:** [date] | **Last Updated:** [date] | **Branch:** [head] → [base]
+
+**Current Status:**
+- Review Decision: [approved/changes_requested/pending]
+- Mergeable: [yes/no/conflicts] 
+- CI Status: [passing/failing/pending]
+- Linked Issues: [list with status]
+
+**Outstanding Items:**
+- [ ] [Specific action item 1]
+- [ ] [Specific action item 2]
+- [ ] [Specific action item 3]
+
+**Completion Summary:**
+[3-5 sentence summary of what needs to be done to get this PR merged, including specific actions, estimated effort, and any dependencies]
+
+**Local Branch Status:**
+[Status of local branch if exists - ahead/behind/in-sync]
+
+---
+
+### Priority & Parallel Work Recommendations
+
+#### High Priority (Complete First)
+1. **[PR Title]** - [Brief reason why priority]
+2. **[PR Title]** - [Brief reason why priority]
+
+#### Medium Priority (Parallel Candidates)
+1. **[PR Title]** - [Can work on while waiting for reviews/CI]
+2. **[PR Title]** - [Independent work, no blockers]
+
+#### Blocked/Waiting
+1. **[PR Title]** - [What it's waiting for]
+
+#### Suggested Parallel Work Groupings
+- **Group A (Documentation/Tests):** [List of PRs that can be worked on together]
+- **Group B (Independent Features):** [List of PRs with no dependencies]
+- **Group C (Review Response):** [PRs waiting for you to respond to feedback]
+
+### Action Plan Summary
+**Immediate Actions (Next 1-2 days):**
+- [ ] [Specific immediate action]
+- [ ] [Specific immediate action]
+
+**This Week:**
+- [ ] [Weekly goal]
+- [ ] [Weekly goal]
+
+**Waiting On Others:**
+- [ ] [What you're waiting for from others]
+
+## Error Handling
+
+If you encounter any errors:
+1. **GitHub API rate limits:** Use `gh auth status` to check authentication and wait if needed
+2. **Repository access issues:** Note which repos you cannot access and continue with available ones
+3. **Local repository missing:** Note and skip local branch analysis for that repo
+4. **Slack access issues:** Continue without Slack data and note the limitation
+
+## Additional Context
+
+Consider these factors in your analysis:
+- **Repository importance** (core vs. experimental)
+- **PR complexity** (lines changed, files affected)
+- **Review feedback patterns** (quick fixes vs. architectural changes)
+- **Team dependencies** (waiting on specific reviewers)
+- **Release timeline pressures** (upcoming deadlines)
+
+Remember: The goal is actionable intelligence - what specific actions will move each PR toward completion, and what can be done in parallel to maximize efficiency.

--- a/.claude/commands/github/GH-PR-implement-review-comments.md
+++ b/.claude/commands/github/GH-PR-implement-review-comments.md
@@ -1,0 +1,165 @@
+# Implement PR Review Comments
+
+You are a senior software engineer tasked with implementing code review feedback professionally and systematically. Your goal is to address all reasonable review comments while maintaining code quality, following repository conventions, and creating clear documentation of changes.
+
+## Context
+The user has received review comments on a pull request and needs to implement the feedback. This process requires careful analysis of each comment, thoughtful implementation of changes, and proper git hygiene with meaningful commit messages that track back to specific review feedback.
+
+## Instructions
+
+<workflow>
+### 1. Fetch and Analyze PR Review Comments
+First, gather all review feedback:
+- Use `gh pr view $ARGUMENTS --comments` to get the PR details and comments
+- Use `gh api repos/:owner/:repo/pulls/$ARGUMENTS/reviews` for detailed review data
+- Identify the current state of the PR branch and ensure you're working on the correct branch
+
+### 2. Categorize and Prioritize Comments
+Organize the feedback systematically:
+- **Actionable comments**: Code changes, bug fixes, improvements
+- **Discussion items**: Questions requiring clarification or design discussions  
+- **Style/convention changes**: Formatting, naming, documentation
+- **Blocking issues**: Critical problems that must be resolved
+- **Optional suggestions**: Nice-to-have improvements
+
+### 3. Address Each Comment Systematically
+For each actionable review comment:
+
+**Assessment Phase:**
+- Read the comment carefully and understand the reviewer's intent
+- Examine the specific code location mentioned
+- Determine if the suggestion is reasonable and aligns with project standards
+- Consider the impact on other parts of the codebase
+
+**Implementation Phase:**
+- Make the requested changes thoughtfully, not just mechanically
+- Ensure changes maintain or improve code quality
+- Test that changes don't break existing functionality
+- Follow existing code patterns and conventions
+
+**Documentation Phase:**
+- Create a focused commit for each logical group of related changes
+- Write clear commit messages that reference the review feedback
+- Use the format: `[type] brief description - addresses review comment by @reviewer`
+
+### 4. Handle Edge Cases
+**For unclear or problematic comments:**
+- Document your interpretation and reasoning
+- Implement what seems most reasonable
+- Prepare questions for follow-up discussion
+
+**For conflicting feedback:**
+- Prioritize based on reviewer seniority and expertise area
+- Document conflicts and resolution approach
+- Consider reaching out for clarification
+
+**For suggestions that would break things:**
+- Document why the suggestion can't be implemented as-is
+- Propose alternative solutions that address the underlying concern
+</workflow>
+
+## Implementation Guidelines
+
+<commit_message_format>
+Use this format for commit messages:
+- `[fix] resolve memory leak in image processor - addresses @reviewer's performance concern`
+- `[refactor] extract validation logic to separate module - per @reviewer's suggestion`
+- `[docs] add detailed API examples - implements @reviewer's documentation request`
+- `[style] use consistent naming for user variables - addresses @reviewer's naming feedback`
+</commit_message_format>
+
+<code_quality_standards>
+**Maintain Quality While Implementing Changes:**
+- Don't just make changes - improve the overall code quality
+- Ensure proper error handling is preserved or added
+- Maintain test coverage for modified areas
+- Follow established patterns and conventions
+- Consider performance implications of changes
+</code_quality_standards>
+
+## Validation Checklist
+Before marking comments as addressed:
+- [ ] All reasonable review comments have been implemented
+- [ ] Each change has been tested locally
+- [ ] Commit messages clearly reference the review feedback
+- [ ] Code follows repository conventions and patterns
+- [ ] No new linting or type-checking errors introduced
+- [ ] Documentation updated if public APIs changed
+- [ ] Test coverage maintained or improved
+
+## Communication Strategy
+
+<comment_responses>
+**Responding to reviewers:**
+- Thank reviewers for their feedback
+- Explain your implementation approach for complex changes
+- Ask for clarification on unclear feedback rather than guessing
+- Document cases where you deviated from suggestions and why
+</comment_responses>
+
+## Examples
+
+<good_practices>
+**Effective Review Comment Implementation:**
+
+*Review Comment*: "This function is doing too much - consider breaking it into smaller, focused functions"
+
+*Good Implementation*:
+- Break function into logical sub-functions
+- Ensure each function has a single responsibility  
+- Add appropriate documentation
+- Commit message: `[refactor] break down processUserData into focused functions - addresses @alice's complexity concern`
+
+*Review Comment*: "Missing error handling for the API call"
+
+*Good Implementation*:
+- Add comprehensive error handling
+- Include appropriate logging
+- Consider retry logic if applicable
+- Test error scenarios
+- Commit message: `[fix] add error handling and retry logic for user API calls - implements @bob's safety suggestion`
+</good_practices>
+
+<poor_practices>
+**Avoid These Approaches:**
+
+*Poor Response to Review*:
+- Making changes without understanding the reasoning
+- Implementing suggestions that break functionality
+- Generic commit messages like "address review comments"
+- Ignoring feedback without explanation
+- Making unrelated changes in the same commit
+
+*Poor Commit Examples*:
+- `fix stuff`
+- `review changes`
+- `updates per feedback`
+</poor_practices>
+
+## Error Handling
+
+**If review comments reference code that no longer exists:**
+- Check if changes were made after the review
+- Explain the current state and how it addresses the concern
+- Suggest alternative improvements if applicable
+
+**If implementing a suggestion would introduce bugs:**
+- Document the issue clearly
+- Propose alternative solutions
+- Explain your reasoning in PR comments
+
+**If you don't understand a comment:**
+- Don't guess - ask for clarification
+- Provide your current understanding for validation
+- Suggest a call or more detailed discussion if needed
+
+## Final Steps
+
+After implementing all changes:
+1. Run the full test suite to ensure nothing is broken
+2. Check linting and type-checking tools
+3. Update the PR description if the scope significantly changed
+4. Reply to review comments explaining your implementations
+5. Request re-review from the original reviewers
+
+**Important**: Never include "Generated with Claude Code" or any reference to AI assistance in commits, PR comments, or code changes.

--- a/.claude/commands/github/GH-create-github-issue.md
+++ b/.claude/commands/github/GH-create-github-issue.md
@@ -1,0 +1,59 @@
+# Create GitHub Issue with Research
+
+For this task: $ARGUMENTS
+
+## Research Phase
+
+1. **Read Issue Templates**
+   - Check if repo exists locally first, otherwise fetch it
+   - Read templates in .github/ISSUE_TEMPLATE/ or .github/ folder
+   - Note required fields, formatting guidelines, and labels
+
+2. **Read Core Documentation:**
+   - https://deepwiki.com/comfyanonymous/ComfyUI (core ComfyUI)
+   - https://deepwiki.com/Comfy-Org/ComfyUI_frontend (frontend architecture)
+   - https://deepwiki.com/Comfy-Org/ComfyUI-Manager (custom node manager)
+   - https://deepwiki.com/Comfy-Org/litegraph.js (graph canvas system)
+   - ~/projects/comfy-testing-environment/
+   - ~/projects/comfyui-frontend-testing/
+   - ~/projects/comfyui-frontend-testing/docs/
+
+3. **Read Repository Documentation**
+   - Look for deepwikis, CONTRIBUTING.md, or other relevant docs
+   - Understand the project's issue reporting standards
+
+4. **Analyze Existing Issues**
+   - Use `gh issue list` and `gh api` to query similar issues
+   - Study formatting, etiquette, and common patterns
+   - Check for duplicates or related discussions
+
+5. **Review Commit History**
+   - Search commits related to the feature/bug area
+   - Understand recent changes that might be relevant
+
+## Visual Documentation (if needed)
+
+If screenshots would help illustrate the issue:
+- Tell me to start ComfyUI in a separate process
+- Once I confirm it's running, navigate to localhost:8188
+- Take relevant screenshots of the issue/feature request
+
+For design specifications or visual details:
+- Visit Figma: https://www.figma.com/files/team/1359619007376639842/recents-and-sharing?fuid=1462318000816924530
+- Capture any relevant design elements
+
+## Create the Issue
+
+Using all gathered information:
+1. Draft issue following the template and standards discovered
+2. Include relevant context, screenshots, and references
+3. Apply appropriate labels and metadata
+4. Use `gh issue create` to submit
+
+Remember to:
+- Be concise but thorough
+- Follow the project's contribution guidelines
+- Reference related issues/PRs where applicable
+- Use clear, descriptive title
+- Include reproduction steps for bugs
+- Specify expected vs actual behavior

--- a/.claude/commands/github/GH-summarize-my-recent-prs.md
+++ b/.claude/commands/github/GH-summarize-my-recent-prs.md
@@ -1,0 +1,31 @@
+Get all pull requests created by christian-byrne in the past 26 hours (whether opened or closed) and provide a nicely formatted list with links and summaries.
+
+Follow these steps:
+
+1. Use `gh pr list` with appropriate filters to get both open and closed PRs from all repositories you have access to
+2. Filter the results to show only PRs created by christian-byrne in the past 26 hours
+3. For each PR, gather:
+   - PR title and number
+   - Repository name
+   - Status (open/closed/merged)
+   - Creation date/time
+   - Direct link to the PR
+   - Brief summary of what the PR does (from the description or title)
+
+4. Format the output as:
+   - A clear header with the time range
+   - Each PR as a bullet point with all the gathered information
+   - Use markdown formatting for better readability
+   - Include clickable links
+
+5. If no PRs are found in the time range, clearly state that
+
+Commands to use:
+- `gh pr list --author=christian-byrne --state=all --limit=50` (to get both open and closed)
+- `gh pr view <PR_NUMBER> --repo <REPO>` to get additional details if needed
+- Use date filtering to ensure only PRs from the past 26 hours are included
+
+Remember to handle cases where:
+- No PRs exist in the timeframe
+- PRs might be from different repositories
+- Some PRs might have minimal descriptions

--- a/.claude/commands/github/PR-submit-local-as-new-pr.md
+++ b/.claude/commands/github/PR-submit-local-as-new-pr.md
@@ -1,0 +1,101 @@
+# Submit Local Changes as New PR
+
+You are a senior DevOps engineer helping to create a clean, professional pull request from local changes. Your goal is to ensure proper git hygiene, meaningful commit messages, and a well-structured PR submission.
+
+## Context
+The user has been working on changes and is ready to submit them as a new pull request. This process requires careful handling of git state, proper branching, and professional PR creation that follows repository conventions.
+
+## Instructions
+
+<workflow>
+Follow these steps systematically to create a clean PR:
+
+### 1. Repository State Assessment
+First, analyze the current git state:
+- Run `git status` to see current changes and branch
+- Run `git log --oneline -5` to understand recent commits
+- Check if we're on an appropriate feature branch or need to create one
+
+### 2. Branch Management
+Handle branching based on current state:
+
+**If on main/master branch OR changes mixed with unrelated work:**
+- Identify and stash only the current session's changes with a clear stash message
+- Checkout main/master and ensure it's up to date (`git fetch && git pull`)
+- Create a new descriptive feature branch following naming conventions
+- Apply the stashed changes (`git stash pop`)
+
+**If already on a clean feature branch:**
+- Verify the branch name is descriptive and appropriate
+- Ensure it's based on the latest main/master
+
+### 3. Commit Creation
+Create a meaningful commit:
+- Stage relevant changes carefully (avoid staging unrelated files)
+- Write a clear, concise commit message following repository conventions
+- Use the format: `[type] brief description` (e.g., `[feat] add user authentication`, `[fix] resolve login timeout issue`)
+- Ensure the commit message explains the "why" not just the "what"
+
+### 4. Push and PR Creation
+Handle repository type appropriately:
+
+**For public repositories:**
+- Push the branch to remote: `git push -u origin <branch-name>`
+- Use GitHub CLI to create PR: `gh pr create --title "descriptive title" --body "brief description"`
+- Ensure PR title is clear and follows repository conventions
+- Write a concise PR description (1-3 sentences maximum) focusing on the value and impact
+
+**For private repositories:**
+- Push the branch: `git push -u origin <branch-name>`
+- Provide the user with the suggested PR title and description for manual creation
+
+### 5. Cleanup and Restoration
+If changes were stashed from another branch:
+- Return to the original branch
+- Restore any unrelated changes that were stashed
+- Verify the original branch state is properly restored
+
+</workflow>
+
+## Validation Steps
+Before completing, verify:
+- [ ] All intended changes are committed
+- [ ] No unintended files are included
+- [ ] Commit message is clear and follows conventions
+- [ ] Branch name is descriptive
+- [ ] PR title and description are concise and meaningful
+- [ ] Any stashed unrelated changes are properly restored
+
+## Error Handling
+If you encounter issues:
+- **Merge conflicts**: Guide through resolution before proceeding
+- **Permission errors**: Check repository access and suggest alternative approaches
+- **Branch naming conflicts**: Suggest alternative branch names
+- **Stash conflicts**: Handle carefully to avoid losing work
+
+## Examples
+
+<commit_message_examples>
+Good commit messages:
+- `[feat] implement user dashboard with analytics widgets`
+- `[fix] resolve memory leak in image processing pipeline`
+- `[docs] update API documentation for authentication endpoints`
+
+Poor commit messages:
+- `fix stuff`
+- `update`
+- `changes`
+</commit_message_examples>
+
+<pr_description_examples>
+Good PR descriptions:
+- `Adds real-time collaboration features to the document editor, enabling multiple users to edit simultaneously with conflict resolution.`
+- `Fixes critical performance issue in the search algorithm that was causing 3+ second delays for large datasets.`
+
+Poor PR descriptions:
+- `Updated some files`
+- `Various improvements`
+- `Bug fixes and enhancements`
+</pr_description_examples>
+
+**Important**: Never include "Generated with Claude Code" or any reference to AI assistance in commit messages, PR titles, or descriptions.

--- a/.claude/commands/github/SOLVEBUG-solve-issue-tdd.md
+++ b/.claude/commands/github/SOLVEBUG-solve-issue-tdd.md
@@ -1,0 +1,92 @@
+# Solve GitHub Issue with Test-Driven Development
+
+Your task is to fetch and solve the GitHub issue: **$ARGUMENTS** using test-driven development (TDD).
+
+## Context
+
+Test-driven development becomes extremely powerful with agentic coding. You will perform best when you have a clear target to iterate against—in this case, test cases that define expected behavior. This workflow ensures robust, well-tested solutions.
+
+## Instructions
+
+Follow these steps in sequence. **Do not skip steps or work ahead.**
+
+### Step 1: Issue Analysis
+<issue_analysis>
+1. Use `gh issue view $ARGUMENTS` to fetch the complete issue details
+2. Understand the problem, requirements, and expected behavior described
+3. Identify the scope of changes needed
+4. Search the codebase for relevant files and existing patterns
+5. **Do not write any code yet** - this is analysis only
+</issue_analysis>
+
+### Step 2: Test Design (TDD Phase 1)
+<test_design>
+1. Based on the issue requirements, write comprehensive tests that define the expected behavior
+2. Focus on **expected input/output pairs** from the issue description
+3. **Be explicit about doing test-driven development** - avoid creating mock implementations for functionality that doesn't exist yet
+4. Write tests that will **fail initially** since the functionality isn't implemented
+5. Include edge cases and error conditions mentioned in the issue
+6. **Do not write any implementation code** - only tests
+</test_design>
+
+### Step 3: Test Verification
+<test_verification>
+1. Run the tests you just created
+2. **Confirm they fail** as expected (this proves the functionality doesn't exist yet)
+3. Verify the test failures are for the right reasons (missing functionality, not syntax errors)
+4. If tests pass unexpectedly, the functionality may already exist - investigate further
+</test_verification>
+
+### Step 4: Commit Tests
+<commit_tests>
+1. Review the tests to ensure they properly capture the issue requirements
+2. When satisfied with test coverage and quality, commit the tests with a descriptive message
+3. Use format: `[test] Add tests for issue #X - [brief description]`
+</commit_tests>
+
+### Step 5: Implementation (TDD Phase 2)
+<implementation>
+1. Now write code that makes the tests pass
+2. **Do not modify the tests** - they define the contract
+3. Implement the minimum functionality needed to pass each test
+4. Run tests frequently and iterate on the implementation
+5. **Keep going until all tests pass** - this may take multiple iterations
+6. Focus on making tests pass first, optimize later if needed
+</implementation>
+
+### Step 6: Verification & Validation
+<verification>
+1. Ensure all tests pass consistently
+2. Run any existing test suites to verify no regressions
+3. **Use independent verification**: Create a subagent to review the implementation and ensure it's not overfitting to the tests
+4. Check that the solution actually addresses the original issue requirements
+5. Test edge cases manually if needed
+</verification>
+
+### Step 7: Final Commit & Cleanup
+<final_commit>
+1. When satisfied with the implementation, commit the code changes
+2. Use format: `[feat] Implement solution for issue #X - [brief description]`
+3. Ensure the solution is complete and ready for review
+4. Run any required linting or formatting tools
+</final_commit>
+
+## Important Notes
+
+- **Do not jump ahead** - follow the TDD workflow strictly
+- **Tests define the contract** - don't modify them during implementation
+- **Iterate until success** - expect multiple rounds of code → test → adjust
+- **Use subagents for verification** to catch overfitting or missed requirements
+- **Focus on the issue requirements** - don't add unnecessary features
+
+## Success Criteria
+
+✅ Issue requirements fully understood  
+✅ Comprehensive tests written and initially failing  
+✅ Tests committed before implementation  
+✅ Implementation makes all tests pass  
+✅ No regressions in existing functionality  
+✅ Independent verification confirms solution quality  
+✅ Final implementation committed  
+
+Begin with Step 1 and work through each phase methodically.

--- a/.claude/commands/notion/NOTION-TASKS-audit-task-view.md
+++ b/.claude/commands/notion/NOTION-TASKS-audit-task-view.md
@@ -1,0 +1,134 @@
+# Audit and Update Notion Task View
+
+You are a productivity analyst helping to ensure task tracking accuracy. Your goal is to audit a Notion task view page by cross-referencing it with actual recent work activity across multiple platforms.
+
+## Task Overview
+
+<task_description>
+Audit the Notion task view page to verify it accurately reflects current and recent work. Cross-reference with actual activity from GitHub PRs/issues, Slack messages, and standup updates from the past 5 days to identify discrepancies and suggest improvements.
+</task_description>
+
+## Step-by-Step Instructions
+
+### 1. Planning Phase
+Use the TodoWrite tool to create a comprehensive task plan with the following items:
+- Fetch current Notion task view page content
+- Retrieve recent GitHub activity (PRs and issues from past 5 days)
+- Collect recent Slack messages from develop, frontend, and general channels
+- Get recent standup updates from the Team Standup page
+- Cross-reference all data sources for consistency
+- Analyze discrepancies and outdated information
+- Generate actionable recommendations for task view improvements
+
+### 2. Data Collection Phase
+
+<data_sources>
+**Primary Sources:**
+- Notion Task View: https://www.notion.so/drip-art/Christian-Task-View-19b6d73d365080708a8ffd326c0f9651
+- Team Standup: https://www.notion.so/drip-art/Team-Standup-1419af591e2b47a4b88af01997f5e0fa
+
+**Activity Sources:**
+- GitHub: Recent PRs and issues (past 5 days)
+- Slack: Messages in #develop, #frontend, #general channels (past 5 days)
+</data_sources>
+
+Execute the following data collection steps:
+
+1. **Notion Data Collection:**
+   - Use the Notion API to retrieve the current task view page content (read-only)
+   - Use the Notion API to retrieve recent standup updates (read-only)
+   - Extract current tasks, their status, priorities, and last update dates
+
+2. **GitHub Activity Collection:**
+   - Use `gh` commands to get recent PRs where you were involved (created, reviewed, commented)
+   - Use `gh` commands to get recent issues where you participated
+   - Focus on activity from the past 5 days
+   - Extract PR/issue titles, status, and your involvement level
+
+3. **Slack Activity Collection:**
+   - Use Slack API to retrieve your recent messages from #develop, #frontend, #general
+   - Focus on messages from the past 5 days
+   - Extract key topics, projects mentioned, and work context
+
+### 3. Cross-Reference Analysis
+
+<analysis_framework>
+Compare and analyze the collected data using these criteria:
+
+**Completeness Check:**
+- Are all active GitHub PRs/issues reflected in the task view?
+- Are current work topics from Slack represented?
+- Are standup commitments tracked as tasks?
+
+**Accuracy Check:**
+- Do task statuses match actual PR/issue states?
+- Are task priorities aligned with recent activity levels?
+- Are completed tasks properly marked as done?
+
+**Currency Check:**
+- Are there outdated tasks that should be archived?
+- Are there new tasks that emerged from recent work?
+- Are task descriptions current and relevant?
+</analysis_framework>
+
+### 4. Generate Recommendations
+
+Provide specific, actionable recommendations in the following format:
+
+<recommendations_structure>
+**Tasks to Add:**
+- List new tasks that should be created based on recent activity
+- Include suggested priority levels and due dates
+
+**Tasks to Update:**
+- List existing tasks that need status or description updates
+- Specify what changes should be made
+
+**Tasks to Archive/Remove:**
+- List outdated or completed tasks that should be cleaned up
+- Explain why they're no longer relevant
+
+**Process Improvements:**
+- Suggest workflow improvements for keeping the task view current
+- Recommend automation or reminder strategies
+</recommendations_structure>
+
+### 5. Output and Implementation Guidance
+
+Since we have read-only access to Notion, provide recommendations in one of these formats:
+
+**Option A: Markdown Report**
+- Create a detailed markdown file with all findings and recommendations
+- Include specific copy-paste instructions for Notion updates
+- Format recommendations as actionable checklists
+
+**Option B: Console Summary**
+- Present findings directly in the console with clear sections
+- Use formatting that's easy to reference while updating Notion manually
+
+For each recommendation, provide:
+- Specific text/content for Notion page updates
+- Priority level (High/Medium/Low) for implementation
+- Estimated time to complete the manual update
+- Step-by-step instructions for making changes in Notion
+
+## Success Criteria
+
+A successful audit should result in:
+- ✅ Complete inventory of current task view vs. actual activity
+- ✅ Identification of all discrepancies and gaps
+- ✅ Specific, actionable recommendations for improvements
+- ✅ Clear implementation guidance with priorities
+- ✅ Suggestions for maintaining accuracy going forward
+
+## Important Notes
+
+- Focus on the past 5 days for activity analysis
+- Be thorough in cross-referencing - don't miss any platforms
+- **We have read-only access to Notion** - provide recommendations as copy-paste instructions
+- Prioritize recommendations based on impact on productivity
+- Consider both immediate fixes and longer-term process improvements
+- If any data source is inaccessible, clearly note this and work with available data
+- Format output for easy manual implementation in Notion
+
+Begin by using the TodoWrite tool to create your task plan, then proceed with systematic data collection and analysis.

--- a/.claude/commands/notion/NOTION-convert-to-bounty-task.md
+++ b/.claude/commands/notion/NOTION-convert-to-bounty-task.md
@@ -1,0 +1,164 @@
+# Convert Task to Bounty Task
+
+Your task is to convert the following task into a properly structured bounty task following the ComfyUI bounty process: $ARGUMENTS
+
+## Process Overview
+
+Follow these steps to convert a task into a bounty task (make it as a markdown file):
+
+### Step 1: Analyze Task Scope
+First, determine if this is a **Task** or **Project**:
+- **Task**: A specific feature or improvement (e.g., new feature in frontend, bug fix, enhancement)
+- **Project**: A larger scope initiative (e.g., entire new frontend, major system overhaul)
+
+### Step 2: Create Bounty Task Entry
+
+For **Tasks**:
+1. **Create the task** under the appropriate project in [Tasks](https://www.notion.so/bf086637f74c4292ae588ab84ff18550?pvs=21):
+   - Frontend tasks → [ComfyUI_Frontend](https://www.notion.so/ComfyUI_Frontend-5fe8e9b691a14389bc25af1e2fc25982?pvs=21)
+   - Desktop tasks → [Comfy Desktop Next](https://www.notion.so/Comfy-Desktop-Next-1f96d73d365080d98d86dd109c0221e6?pvs=21)
+   - Core/Backend tasks → Appropriate backend project
+   
+2. **Mark as Bounty**: Set the `Tag` field to "Bounty" 
+   - ⚠️ **SECURITY WARNING**: This makes the task PUBLIC automatically
+   - Do NOT include sensitive details, internal links, or proprietary information
+   
+3. **Set Bounty Category**: Go to "💰 Bounty Task" section and categorize appropriately
+4. **[Optional]** Write detailed description in Comfy
+5. **[Optional]** Create GitHub Issue and link it in the task
+
+For **Projects**:
+1. **Create project** under [Projects](https://www.notion.so/61fcba01de44437c9b041aa4c12b0a5e?pvs=21)
+2. **Mark as "Contractor-Needed"**
+3. **Write comprehensive project details** in Notion or GitHub Issue
+
+### Step 3: Structure the Bounty Task
+
+Create a well-structured bounty task with these sections:
+
+#### Required Sections:
+- **Title**: Clear, concise description of what needs to be done
+- **Description**: Detailed explanation of the task requirements
+- **Acceptance Criteria**: Specific, measurable outcomes
+- **Priority Level**: High/Medium/Low
+- **Estimated Effort**: Hours or complexity level
+- **Skills Required**: Technical skills needed
+- **Resources**: Links to relevant documentation, examples, or codebases
+
+#### Recommended Additional Sections:
+- **Background/Context**: Why this task is important
+- **Technical Approach**: Suggested implementation strategy
+- **Testing Requirements**: How to verify the solution works
+- **Deliverables**: What exactly should be submitted
+
+## Context & Resources
+
+### ComfyUI Ecosystem Resources:
+- **Main Repository**: [ComfyUI GitHub](https://github.com/comfyanonymous/ComfyUI)
+- **Frontend Repository**: [ComfyUI Frontend](https://github.com/Comfy-Org/ComfyUI_frontend)
+- **ComfyUI CLI**: [Comfy CLI](https://github.com/Comfy-Org/comfy-cli)
+- **ComfyUI Desktop**: [Desktop App](https://github.com/Comfy-Org/desktop)
+- **Documentation**: [ComfyUI Docs](https://docs.comfy.org/)
+- **Node Registry**: [ComfyUI Registry](https://registry.comfy.org/)
+- **Example Workflows**: [Example Workflows](https://github.com/Comfy-Org/example_workflows)
+- **Community**: [ComfyUI Discord](https://discord.com/invite/comfyorg)
+
+### Bounty Management:
+- **Internal View**: [Bounty Tasks View (Internal)](https://www.notion.so/Bounty-Tasks-View-Internal-2006d73d365080eaae35edac894860c9?pvs=21)
+- **Public View**: [ComfyUI Bounty Tasks](https://www.notion.so/ComfyUI-Bounty-Tasks-1fb6d73d36508064af76d05b3f35665f?pvs=21)
+
+### Technical Guidelines:
+- **Installation Guide**: [System Requirements](https://docs.comfy.org/installation/system_requirements)
+- **Development Overview**: [Development Guide](https://docs.comfy.org/development/overview)
+- **Frontend Development**: [Frontend Repository](https://github.com/Comfy-Org/ComfyUI_frontend)
+- **Core Backend**: [Main Repository](https://github.com/comfyanonymous/ComfyUI)
+- **CLI Tools**: [Comfy CLI](https://github.com/Comfy-Org/comfy-cli)
+- **Desktop App**: [Desktop Repository](https://github.com/Comfy-Org/desktop)
+
+## Best Practices & Tips
+
+### Writing Effective Bounty Tasks:
+1. **Be Specific**: Avoid vague requirements like "improve performance"
+2. **Include Examples**: Reference existing implementations or similar features
+3. **Set Clear Boundaries**: Define what's in scope and what's not
+4. **Provide Context**: Explain the business value and user impact
+5. **Consider Skill Level**: Match complexity to expected contributor experience
+
+### Common Bounty Categories:
+- **Frontend/UI**: User interface improvements, new components, UX enhancements
+- **Backend/Core**: API improvements, performance optimizations, new core features  
+- **Core Nodes**: Built-in node improvements, new core node types, optimization
+- **Documentation**: Guides, tutorials, API documentation, examples
+- **Testing**: Unit tests, integration tests, test automation
+- **DevOps**: Build improvements, deployment automation, monitoring
+- **CLI/Desktop**: Command-line tools and desktop application improvements
+
+### Security Considerations:
+- Never include API keys, passwords, or sensitive configuration
+- Avoid exposing internal system architecture details
+- Don't reference internal-only repositories or resources
+- Use placeholder values for sensitive data in examples
+
+### Pricing Guidelines:
+- **Simple tasks** (1-4 hours): $50-200
+- **Medium tasks** (4-16 hours): $200-800  
+- **Complex tasks** (16+ hours): $800+
+- **Projects**: Negotiate based on scope
+
+## Example Task Conversions
+
+### Example 1: Frontend Enhancement
+**Original**: "Make the workflow editor better"
+**Converted Bounty Task**:
+- **Title**: Add Workflow Node Search and Filter Functionality
+- **Description**: Implement search and filtering capabilities in the workflow editor to help users quickly find and organize nodes
+- **Acceptance Criteria**: 
+  - Search bar that filters nodes by name/category in real-time
+  - Category filter dropdown with node type groupings
+  - Keyboard shortcuts for search (Ctrl+F)
+  - Search history (last 5 searches)
+- **Skills Required**: JavaScript, Vue.js, CSS
+- **Estimated Effort**: 8-12 hours
+- **Resources**: [Frontend Repository](https://github.com/Comfy-Org/ComfyUI_frontend), [JS Extensions Guide](https://docs.comfy.org/custom-nodes/js/javascript_overview)
+
+### Example 2: Node Development
+**Original**: "Need better image processing"
+**Converted Bounty Task**:
+- **Title**: Create Advanced Image Enhancement Node Pack
+- **Description**: Develop a collection of image processing nodes including noise reduction, sharpening, and color correction
+- **Acceptance Criteria**:
+  - 5 new nodes: Denoise, Sharpen, Color Correct, Brightness/Contrast, Saturation
+  - Each node with parameter controls and real-time preview
+  - Comprehensive documentation and examples
+  - Unit tests for each node
+- **Skills Required**: Python, Image Processing (PIL/OpenCV), ComfyUI Core API
+- **Estimated Effort**: 20-30 hours
+- **Resources**: [Core Repository](https://github.com/comfyanonymous/ComfyUI), [Development Overview](https://docs.comfy.org/development/overview)
+
+## Validation Checklist
+
+Before finalizing the bounty task:
+- [ ] Task scope is clearly defined and achievable
+- [ ] Acceptance criteria are specific and measurable  
+- [ ] No sensitive information is included
+- [ ] Appropriate project category is selected
+- [ ] Effort estimation is realistic
+- [ ] Required skills are clearly listed
+- [ ] Relevant resources and links are provided
+- [ ] Task is tagged as "Bounty" in Notion
+- [ ] Bounty category is set appropriately
+
+## Next Steps
+
+After creating the bounty task:
+1. **Review** with team lead for approval
+2. **Publish** to public bounty board
+3. **Monitor** for questions and applications
+4. **Select** qualified contributor
+5. **Provide** ongoing support during development
+6. **Review** and approve final deliverables
+7. **Process** payment upon completion
+
+---
+
+**Note**: This command follows the official ComfyUI bounty process. Always ensure tasks meet quality standards and provide clear value to the community before publishing.

--- a/.claude/commands/research/STUDY-comfy-api-architecture.md
+++ b/.claude/commands/research/STUDY-comfy-api-architecture.md
@@ -1,0 +1,880 @@
+Please read the following architecture overview for the comfy-api repo and use as a guide for following tasks (will explain later after you have finished reading):
+
+# ComfyUI Registry Backend - Architecture Overview
+
+## 🎓 Backend Development Fundamentals
+
+### For CS Developers New to Backend/Database Development
+
+This document assumes familiarity with CS concepts but introduces backend-specific patterns. Here are the key paradigms this system demonstrates:
+
+#### **Database-Centric Architecture**
+Unlike frontend development where data is ephemeral, backend systems are built around **persistent data models**. This repo uses:
+- **PostgreSQL**: A relational database where data is structured in tables with relationships
+
+> **📖 PostgreSQL Explained**: PostgreSQL (often called "Postgres") is like the Swiss Army knife of databases. Born at UC Berkeley in 1986, it pioneered advanced features like JSON columns, full-text search, and custom data types while maintaining strict ACID compliance. Unlike MySQL (speed-focused) or SQLite (embedded), PostgreSQL balances performance with features. It supports both relational and NoSQL patterns, making it ideal for complex applications. The "Post" refers to its successor status to the earlier INGRES database project.
+- **EntGo ORM (Object-Relational Mapping)**: Maps database tables to Go structs, eliminating SQL (Structured Query Language - database query language) boilerplate (see `ent/schema/*.go`)
+
+> **📖 EntGo Name Origin**: "Ent" comes from Tolkien's Lord of the Rings - tree-like creatures that are ancient, persistent, and guardians of data (forests). Perfect metaphor for an ORM that guards your database schema! Facebook chose this name because ORMs manage the "roots" of your application (data models) and grow into complex relationship trees.
+
+- **ACID Transactions (Atomicity, Consistency, Isolation, Durability)**: Database operations are atomic, consistent, isolated, and durable
+
+> **📖 ACID Explained**: ACID guarantees are like safety contracts for your data. **Atomicity**: all-or-nothing (bank transfer either debits AND credits, or neither). **Consistency**: database rules always hold (can't have negative account balance). **Isolation**: concurrent operations don't interfere (two people can't withdraw the last $10 simultaneously). **Durability**: committed data survives crashes (your payment confirmation means it's really saved). Without ACID, databases would be unreliable for financial/critical data.
+
+**Go Structs Explained**: A struct is Go's equivalent to a class without methods - a composite data type that groups related fields:
+```go
+type Node struct {
+    ID          string    `json:"id"`
+    Name        string    `json:"name"`
+    Description *string   `json:"description,omitempty"` // pointer = nullable
+    CreatedAt   time.Time `json:"created_at"`
+}
+```
+**Key Differences from Python dicts/JS objects**:
+- **Strongly Typed**: Each field has a fixed type, enforced at compile time
+- **Memory Layout**: Fields stored contiguously in memory (like C structs)
+- **Tags**: Metadata strings (backticks) control JSON serialization, DB mapping, validation
+- **Pointer vs Value**: `*string` means nullable, `string` means required
+
+> **📖 Pointers Explained**: A pointer is a variable that stores a memory address rather than a value directly. In Go, `*string` means "pointer to string" - it can be `nil` (null) or point to an actual string. Regular `string` is a value type that's always initialized. Think of pointers like house addresses: the address itself isn't the house, but tells you where to find it. Pointers enable nullable fields, shared memory, and efficient large data passing.
+
+- **Zero Values**: Uninitialized fields get type defaults (empty string, 0, false, nil)
+- **No Dynamic Fields**: Cannot add fields at runtime (unlike JS objects)
+
+#### **API Design Patterns**
+- **RESTful APIs (Representational State Transfer Application Programming Interfaces)**: HTTP (HyperText Transfer Protocol) verbs (GET, POST, PUT, DELETE) map to database operations (CRUD - Create, Read, Update, Delete)
+
+> **📖 RESTful Explained**: REST is an architectural style invented by Roy Fielding that treats web resources as nouns (URLs like `/nodes/123`) and HTTP verbs as actions. Unlike RPC-style APIs where you call functions (`getNode(123)`), REST maps intuitive actions: GET `/nodes` (list all), POST `/nodes` (create), PUT `/nodes/123` (update), DELETE `/nodes/123` (remove). This creates predictable, cacheable APIs that web browsers understand natively.
+
+- **Request/Response Cycle**: Every API call follows: validate → business logic → database → response
+- **Middleware Chain**: Cross-cutting concerns (auth, logging, rate limiting) applied declaratively (see `server/middleware/`)
+
+> **📖 Middleware Explained**: Middleware are functions that execute in a chain before your main handler, like Russian nesting dolls. Each middleware can inspect/modify the request, decide to continue or abort, and clean up after. Think of airport security: passport check → security scan → boarding pass → plane. In code: `auth → logging → rate-limiting → your-handler`. This pattern keeps concerns separated and reusable across endpoints.
+
+#### **Service-Oriented Architecture**
+- **Business Logic Layer**: Pure functions that operate on domain entities (see `services/`)
+
+> **📖 Business Logic Explained**: Business logic is the core rules and workflows that make your application unique - not the technical plumbing. For ComfyUI Registry, business logic includes "a node must pass security scanning before publication" or "publishers can only edit their own nodes." It's the domain knowledge that would exist even if you switched from PostgreSQL to MongoDB or from HTTP to GraphQL. Keeping business logic separate from database/HTTP code makes it testable and reusable.
+
+- **Data Access Layer**: Database queries abstracted behind interfaces (see `ent/`)
+- **Integration Layer**: External service calls (Stripe, Algolia) isolated for testing (see `gateways/`)
+
+#### **Stateless vs Stateful Design**
+- **Stateless**: Each request contains all needed info; servers can be killed/restarted freely
+- **Database as Single Source of Truth**: All persistent state lives in PostgreSQL
+- **Caching**: Temporary state (Ristretto cache) for performance, never authoritative
+
+#### **Concurrent Programming**
+- **Goroutines**: Lightweight threads for handling multiple requests (Go's killer feature)
+
+> **📖 Goroutines Explained**: In traditional languages, threads are expensive (1-2MB each) and creating thousands crashes your system. Goroutines are Go's lightweight threads (2KB each) that can spawn millions without issues. They're multiplexed onto OS threads automatically. Think of threads as heavy trucks (expensive, limited) vs goroutines as bicycles (cheap, unlimited). This lets Go handle 10,000 concurrent HTTP requests with ease, whereas traditional servers would collapse.
+
+- **Database Connection Pooling**: Limited connections shared across requests
+
+> **📖 Connection Pooling Explained**: Database connections are expensive to create (handshakes, authentication, memory allocation). Instead of creating/destroying connections per request, connection pools maintain a cache of ready-to-use connections. It's like a taxi dispatcher: instead of manufacturing a new taxi for each passenger, keep a fleet of 10 taxis serving all customers. This transforms O(requests) connection overhead into O(1).
+
+- **Pub/Sub Messaging (Publish/Subscribe)**: Asynchronous processing for expensive operations (see node publishing flow)
+
+> **📖 Pub/Sub Explained**: Publisher/Subscriber is like a newspaper delivery system. Publishers (newspaper companies) send messages to topics (like "Sports" or "Politics"). Subscribers (readers) register interest in topics and receive all messages. Unlike direct API calls, pub/sub is asynchronous - publishers don't wait for subscribers to process messages. Perfect for "fire and forget" operations like sending emails or processing file uploads.
+
+#### **Infrastructure as Code**
+- **Containers**: Applications packaged with dependencies (see `Dockerfile`)
+- **Orchestration**: Cloud platforms manage scaling, health checks, deployments (see `infrastructure/`)
+- **Observability**: Logging, metrics, tracing for production debugging (see New Relic integration)
+
+---
+
+## Executive Summary
+
+The ComfyUI Registry Backend is a sophisticated **Go-based microservice** that powers the [ComfyUI Registry](https://registry.comfy.org) and [ComfyUI CI/CD](https://ci.comfy.org) platforms. It serves as the central hub for managing custom ComfyUI node packs, handling API proxying for multiple AI services, and providing a complete developer ecosystem for the ComfyUI community.
+
+**Key Functions:**
+- 🎨 **Node Registry**: Manages 1000+ custom ComfyUI node packages with versioning, reviews, and discovery
+- 🔌 **API Proxy**: Unified gateway to 15+ AI APIs (OpenAI, Stability, Runway, etc.) with billing aggregation  
+- 🚀 **CI/CD Platform**: Automated testing and deployment for ComfyUI extensions
+- 💳 **Billing & Usage**: Integrated Stripe/Metronome for usage-based pricing across services
+- 🔍 **Search & Discovery**: Algolia-powered search with intelligent categorization
+
+---
+
+## 🏗️ System Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        WEB[Registry Web Frontend]
+        CLI[ComfyUI CLI]
+        CUI[ComfyUI Desktop App]
+        API_CLIENTS[API Clients]
+    end
+
+    subgraph "Load Balancer & Gateway"
+        LB[Google Cloud Load Balancer]
+        CDN[Cloud CDN]
+    end
+
+    subgraph "Core API Service"
+        ECHO[Echo HTTP Server]
+        AUTH[Authentication Layer]
+        MIDDLEWARE[Middleware Stack]
+        
+        subgraph "Business Logic"
+            REG_SVC[Registry Service]
+            API_SVC[ComfyAPI Service] 
+            CI_SVC[CI/CD Service]
+        end
+        
+        subgraph "API Handlers"
+            REG_API[Registry Endpoints]
+            PROXY_API[API Proxy Endpoints]
+            USER_API[User Management]
+            BILLING_API[Billing Endpoints]
+        end
+    end
+
+    subgraph "External Services"
+        FIREBASE[Firebase Auth]
+        ALGOLIA[Algolia Search]
+        STRIPE[Stripe Payments]
+        METRONOME[Metronome Billing]
+        
+        subgraph "AI API Providers"
+            OPENAI[OpenAI]
+            STABILITY[Stability AI]
+            RUNWAY[Runway ML]
+            BFL[Black Forest Labs]
+            KLING[Kling AI]
+            OTHERS[10+ Other APIs]
+        end
+    end
+
+    subgraph "Infrastructure"
+        DB[(PostgreSQL Database)]
+        STORAGE[Cloud Storage]
+        PUBSUB[Pub/Sub Messaging]
+        MONITOR[New Relic Monitoring]
+    end
+
+    subgraph "DevOps & Deployment"
+        DOCKER[Docker Containers]
+        GCR[Google Cloud Run]
+        GCD[Google Cloud Deploy]
+        TERRAFORM[Terraform IaC]
+    end
+
+    WEB --> LB
+    CLI --> LB
+    CUI --> LB
+    API_CLIENTS --> LB
+    
+    LB --> ECHO
+    CDN --> ECHO
+    
+    ECHO --> AUTH
+    AUTH --> MIDDLEWARE
+    MIDDLEWARE --> REG_SVC
+    MIDDLEWARE --> API_SVC
+    MIDDLEWARE --> CI_SVC
+    
+    REG_SVC --> REG_API
+    API_SVC --> PROXY_API
+    CI_SVC --> USER_API
+    
+    AUTH --> FIREBASE
+    REG_SVC --> ALGOLIA
+    API_SVC --> STRIPE
+    API_SVC --> METRONOME
+    
+    PROXY_API --> OPENAI
+    PROXY_API --> STABILITY
+    PROXY_API --> RUNWAY
+    PROXY_API --> BFL
+    PROXY_API --> KLING
+    PROXY_API --> OTHERS
+    
+    REG_SVC --> DB
+    API_SVC --> DB
+    CI_SVC --> DB
+    
+    REG_SVC --> STORAGE
+    API_SVC --> STORAGE
+    
+    REG_SVC --> PUBSUB
+    API_SVC --> PUBSUB
+    
+    ECHO --> MONITOR
+    
+    GCR --> DOCKER
+    GCD --> GCR
+    TERRAFORM --> GCR
+```
+
+---
+
+## 📊 Database Schema & Entity Relationships
+
+### 🎓 Database Fundamentals Primer
+
+**Relational Databases** organize data in tables with predefined schemas. Unlike NoSQL (document/key-value stores), relational DBs enforce **referential integrity** - relationships between entities are guaranteed to be valid.
+
+**Key Concepts Demonstrated:**
+- **Primary Keys (PK)**: Unique identifier for each row (like array indices, but immutable)
+
+> **📖 Immutability Explained**: In programming, immutable means "cannot be changed after creation." Primary keys are immutable because changing them would break all foreign key references - like changing your social security number would break all systems that reference it. Immutable data structures prevent bugs by eliminating "spooky action at a distance" where modifying data in one place unexpectedly affects another. Go encourages immutability through value types and explicit copying.
+- **Foreign Keys (FK)**: References to other table's primary keys (like pointers between objects)  
+- **Unique Constraints (UK)**: Enforces no duplicates (like Set data structure)
+- **Indexes**: B-tree structures for fast lookups (like hash tables for range queries)
+
+> **📖 B-Trees Explained**: B-trees are the secret sauce behind fast database queries. Unlike hash tables (O(1) for exact matches only), B-trees support range queries in O(log n) time. They're like a well-organized library: books sorted by author allow you to quickly find "all books by authors M-P" without scanning everything. B-trees stay balanced automatically as data grows, maintaining logarithmic performance even with billions of records. Every database index uses B-trees or B+ trees under the hood.
+- **ACID Properties**: Transactions ensure data consistency even with concurrent access
+
+**ORM (Object-Relational Mapping)**: EntGo generates Go structs from schema definitions in `ent/schema/`, automatically handling:
+- SQL (Structured Query Language) query generation
+
+> **📖 Code Generation Explained**: Instead of writing repetitive boilerplate by hand, code generation analyzes your schema files and automatically produces type-safe database code. It's like having an AI assistant that writes perfect SQL queries, struct definitions, and validation logic based on your high-level descriptions. Benefits: zero typos, instant refactoring, consistent patterns. Languages use codegen to bridge the gap between human-friendly specifications and machine-optimized implementations.
+
+- Type-safe database operations  
+- Relationship loading (N+1 query prevention)
+- Migration management
+
+> **📖 Atlas Explained**: Atlas is like Git for your database schema. Traditional database migrations are irreversible scripts that can break production if written incorrectly. Atlas treats schema as declarative state (like Infrastructure as Code) and generates safe migration paths automatically. It can preview changes, detect conflicts, and rollback failed migrations. Think of it as "Terraform for databases" - you describe what you want, Atlas figures out how to get there safely.
+
+```mermaid
+erDiagram
+    User {
+        string id PK "Firebase UID"
+        string email
+        string name
+        bool is_approved
+        bool is_admin
+        enum status "ACTIVE|BANNED"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    Customer {
+        string id PK "Firebase UID"
+        string email
+        string name
+        string stripe_customer_id UK
+        string metronome_customer_id UK
+        string metronome_contract_id
+        bool is_admin
+        bool has_fund
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    Publisher {
+        string id PK
+        string name
+        string description
+        string website
+        string support_email
+        string source_code_repo
+        string logo_url
+        enum status "ACTIVE|BANNED"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    Node {
+        string id PK
+        string normalized_id UK
+        string publisher_id FK
+        string name
+        string description
+        string category
+        string author
+        string license
+        string repository_url
+        string normalized_repository_url
+        string icon_url
+        string[] tags
+        int64 total_install
+        int64 total_star
+        int64 total_review
+        enum status "active|deleted|banned"
+        string status_detail
+        timestamp last_algolia_index_time
+        int search_priority "1-10, lower=higher priority"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    NodeVersion {
+        string id PK
+        string node_id FK
+        string version
+        string changelog
+        string download_url
+        string file_hash
+        int64 file_size
+        json dependencies
+        json python_dependencies
+        enum status "active|deprecated|hidden"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    NodeReview {
+        string id PK
+        string node_id FK
+        string user_id FK
+        int rating "1-5"
+        string comment
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    PublisherPermission {
+        string id PK
+        string publisher_id FK
+        string user_id FK
+        enum permission_type "admin|collaborator|viewer"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    APIKey {
+        string id PK
+        string customer_id FK
+        string name
+        string key_hash
+        string key_prefix
+        bool is_active
+        timestamp last_used_at
+        timestamp expires_at
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    AuditLog {
+        string id PK
+        string customer_id FK
+        string action
+        string resource_type
+        string resource_id
+        json metadata
+        timestamp created_at
+    }
+
+    User ||--o{ PublisherPermission : "has permissions"
+    User ||--o{ NodeReview : "writes reviews"
+    
+    Customer ||--o{ APIKey : "owns"
+    Customer ||--o{ AuditLog : "generates"
+    
+    Publisher ||--o{ Node : "publishes"
+    Publisher ||--o{ PublisherPermission : "grants access"
+    
+    Node ||--o{ NodeVersion : "has versions"
+    Node ||--o{ NodeReview : "receives reviews"
+    
+    Node }o--|| Publisher : "belongs to"
+    NodeReview }o--|| User : "written by"
+    NodeReview }o--|| Node : "reviews"
+    PublisherPermission }o--|| User : "grants to"
+    PublisherPermission }o--|| Publisher : "controls"
+    APIKey }o--|| Customer : "belongs to"
+    AuditLog }o--|| Customer : "tracks"
+```
+
+---
+
+## 🔧 Technology Stack & Library Analysis
+
+### 🎓 Backend Technology Patterns
+
+**HTTP (HyperText Transfer Protocol) Frameworks**: Unlike frontend frameworks (React/Vue) that manage UI (User Interface) state, backend frameworks handle request routing, middleware chains, and response formatting. They're closer to Express.js in Node.js.
+
+**Database Layers**: Backend systems typically have 3 layers:
+1. **Schema Definition** (`ent/schema/`): Like TypeScript interfaces but enforced at DB (Database) level
+2. **Query Builder** (EntGo): Type-safe SQL (Structured Query Language) generation  
+3. **Business Logic** (`services/`): Domain operations using entities
+
+**Middleware Pattern**: Functions that wrap request handlers, similar to Python decorators or React HOCs (Higher-Order Components). Each middleware can:
+- Modify request/response
+- Short-circuit the chain (for auth failures)
+- Add context (user info, request IDs)
+
+**Gateway Pattern**: Abstracts external services behind interfaces, enabling:
+- Mock implementations for testing
+- Service substitution without code changes
+- Centralized error handling and retry logic
+
+### Core Framework
+- **Echo v4.11.4**: High-performance HTTP framework chosen for its middleware ecosystem, minimal overhead, and excellent routing capabilities. Popular in Go for its balance of simplicity and power.
+
+### Database & ORM
+- **EntGo v0.14.4**: Facebook's Go ORM (Object-Relational Mapping) providing type-safe database operations with code generation. Solves the traditional Go database verbosity problem while maintaining performance.
+- **PostgreSQL**: Primary database via `lib/pq` driver
+- **Atlas**: Database migration management with version control
+
+### Authentication & Security  
+- **Firebase Admin SDK (Software Development Kit)**: Handles JWT (JSON Web Token) validation and user management
+
+> **📖 SDK Explained**: A Software Development Kit is a collection of tools, libraries, documentation, and examples that make it easier to build applications for a specific platform. Think of it as a toolkit: instead of building a hammer from raw metal, the SDK provides pre-made tools. Firebase SDK handles complex tasks like cryptographic verification, token refresh, and API communication so developers can focus on business logic rather than authentication plumbing.
+
+- **JWT (JSON Web Token, golang-jwt/jwt)**: Multiple versions for compatibility with different token formats
+
+> **📖 JWT Explained**: JSON Web Tokens are like tamper-proof ID cards for the internet. Structure: Header (algorithm) + Payload (user data) + Signature (cryptographic proof). Unlike sessions stored on servers, JWTs are self-contained - all user info is in the token itself. The signature ensures nobody can forge or modify tokens without the secret key. This enables stateless authentication: servers don't need to "remember" logged-in users, making horizontal scaling trivial.
+
+> **📖 Authentication Explained**: Authentication has evolved from simple passwords to sophisticated systems. **Traditional**: server stores sessions in memory/database (stateful, doesn't scale). **Modern**: cryptographic tokens prove identity without server storage (stateless, scales infinitely). **OAuth/OIDC**: delegate authentication to trusted providers (Google, Auth0) instead of handling passwords yourself. **Multi-factor**: combine something you know (password) + something you have (phone) + something you are (biometric) for stronger security.
+
+- **Real IP Detection**: `tomasen/realip` for accurate client IP (Internet Protocol) extraction behind proxies
+
+### External Service Integration
+- **Google Cloud APIs (Application Programming Interfaces)**: Comprehensive integration (Storage, Pub/Sub, Monitoring, Compute)
+- **Stripe SDK (Software Development Kit) v82**: Payment processing and subscription management
+- **Algolia v3**: Search and discovery with real-time indexing
+- **New Relic**: Application performance monitoring and observability (APM - Application Performance Monitoring)
+
+> **📖 New Relic Explained**: New Relic is an observability platform that monitors application performance in production. It tracks metrics like response times, error rates, throughput, and database queries across your entire stack. Unlike simple logging, New Relic provides real-time dashboards, alerting, and distributed tracing to help debug issues in complex microservice architectures. It answers questions like "why is my API slow?" or "which database query is causing timeouts?" Essential for maintaining SLAs in production systems.
+
+### Performance & Caching
+- **Ristretto v2**: High-performance in-memory cache for hot data
+
+> **📖 Ristretto vs Redis Explained**: **Ristretto** is an in-process cache (same memory as your application) optimized for high throughput and low latency - think of it as ultra-fast local storage. **Redis** is an external cache server (separate process/machine) that's slower but shared across multiple application instances. Ristretto is perfect for read-heavy data that doesn't change often (user profiles, configuration). Redis is better for data that needs to be shared or persisted across app restarts. The tradeoff: Ristretto = faster but isolated, Redis = slower but shared.
+
+> **📖 Caching Strategies Explained**: **Cache-Aside**: app manages cache manually (read from cache, if miss then read from DB and populate cache). **Write-Through**: writes go to cache and DB simultaneously (slower writes, consistent data). **Write-Behind**: writes go to cache immediately, DB updated asynchronously (faster writes, risk of data loss). **TTL (Time-To-Live)**: cache entries expire automatically to prevent stale data. **LRU (Least Recently Used)**: evict oldest unused items when cache is full.
+
+- **Brotli & gzip**: Multi-level compression for bandwidth optimization
+
+> **📖 Compression Explained**: **Gzip** (1992) uses LZ77 algorithm for general-purpose compression, reducing text by ~70%. **Brotli** (2015, Google) uses advanced techniques achieving ~20% better compression than gzip with similar speed. Both are lossless - perfect reconstruction guaranteed. The choice: gzip for universal compatibility, Brotli for modern browsers wanting maximum bandwidth savings. This system uses both: Brotli for new clients, gzip fallback for old ones.
+
+### Development & Testing
+- **Testcontainers**: Docker-based integration testing
+- **Air**: Live reload during development
+
+> **📖 Air Explained**: Air is like nodemon for Go - it watches your source files and automatically rebuilds/restarts your server when changes are detected. Without Air, you'd manually stop the server, run `go build`, start the server after every code change. Air automates this cycle, providing instant feedback during development. It's especially valuable for Go since compilation is required (unlike interpreted languages). Think of it as a development accelerator that eliminates the "edit-compile-run" friction.
+
+- **OpenAPI (Open Application Programming Interface) Codegen**: Automatic API client/server generation
+
+> **📖 OpenAPI Explained**: OpenAPI (formerly Swagger) is like a contract for your API - a machine-readable specification describing every endpoint, parameter, and response. From this single YAML file, tools can generate: client SDKs in any language, server stubs, interactive documentation, validation code, and test cases. It's "API-first development": design the interface before implementation, ensuring frontend/backend teams can work in parallel. Changes to the spec automatically propagate to all generated code.
+
+### Why These Libraries Were Chosen
+
+1. **Echo over Gin/Fiber**: Better middleware ecosystem and stability for enterprise use
+
+> **📖 Gin vs Fiber vs Echo Explained**: **Gin** prioritizes raw speed with minimal features - great for microservices but lacks enterprise middleware. **Fiber** mimics Express.js syntax but has a smaller ecosystem and breaking changes between versions. **Echo** balances performance with a mature middleware ecosystem (auth, CORS, rate limiting) and stable APIs. For production systems handling complex requirements, Echo's reliability trumps Gin's speed. Think: Gin = race car, Fiber = sports car, Echo = luxury sedan.
+
+2. **EntGo over GORM (Go Object-Relational Mapping)**: Type safety and code generation reduce runtime errors  
+3. **Ristretto over Redis (Remote Dictionary Server)**: In-memory caching eliminates network latency for hot data
+4. **Firebase over Auth0**: Google ecosystem integration and cost efficiency
+
+> **📖 Auth0 vs Firebase Auth Explained**: **Auth0** is authentication-as-a-service with extensive customization, social logins, and enterprise features (SSO, MFA). **Firebase Auth** is Google's simpler, cheaper alternative integrated with their ecosystem. Auth0 offers more flexibility but costs more and adds vendor dependency. Firebase Auth is free for most use cases and seamlessly integrates with Google Cloud services. Choice depends on complexity: Auth0 for enterprise needs, Firebase for simple authentication with Google services.
+
+5. **Algolia over Elasticsearch**: Managed service reduces operational overhead
+
+> **📖 Elasticsearch vs Algolia Explained**: **Elasticsearch** is a self-hosted search engine offering maximum control and customization - you manage clusters, sharding, indexing strategies. **Algolia** is search-as-a-service: upload data, get instant search with features like typo tolerance, faceting, and geo-search. Elasticsearch is powerful but requires dedicated ops team. Algolia is expensive but eliminates operational complexity. Trade-off: control vs convenience, cost vs complexity.
+
+---
+
+## 🚀 Service Architecture Deep Dive
+
+### Registry Service (`services/registry/`)
+**Primary Function**: Manages the ComfyUI node ecosystem
+
+**Key Responsibilities:**
+- Node publishing, versioning, and lifecycle management
+- Security scanning integration via private Google Cloud Function
+- Algolia search index management and synchronization
+- Publisher management and permission systems
+- Review and rating aggregation
+
+**Notable Patterns:**
+- Event-driven architecture using Google Pub/Sub for async processing
+- Webhook integration for external CI/CD triggers
+- File integrity verification using SHA256 hashing
+
+### ComfyAPI Service (`services/comfy_api/`)
+**Primary Function**: Unified API gateway and billing aggregation
+
+**Supported Providers:**
+```
+┌─────────────────┬──────────────────┬─────────────────────┐
+│ Provider        │ Capabilities     │ Billing Model       │
+├─────────────────┼──────────────────┼─────────────────────┤
+│ OpenAI          │ LLM, Vision      │ Token-based         │
+│ Stability AI    │ Image Generation │ Per-image           │
+│ Runway ML       │ Video Generation │ Per-second          │
+│ Black Forest    │ Image/Video      │ Per-generation      │
+│ Kling AI        │ Video Creation   │ Per-minute          │
+│ Ideogram        │ Text-to-Image    │ Per-image           │
+│ Recraft         │ Design Assets    │ Per-generation      │
+│ Luma Labs       │ 3D Generation    │ Per-model           │
+│ PixVerse        │ Video Editing    │ Per-operation       │
+│ Pika Labs       │ Video Creation   │ Per-generation      │
+│ Tripo3D         │ 3D Modeling      │ Per-model           │
+│ Moonvalley      │ Video Generation │ Per-generation      │
+└─────────────────┴──────────────────┴─────────────────────┘
+```
+
+**Key Features:**
+- Request/response proxying with authentication injection
+- Usage tracking and billing aggregation via Metronome
+- Rate limiting and quota management per customer
+- Error handling and retry logic with circuit breakers
+
+### CI/CD Service (`services/comfy_ci/`)
+**Primary Function**: Automated testing and deployment pipeline
+
+**Workflow:**
+1. GitHub webhook triggers on repository changes
+2. Security scanning via private Google Cloud Function
+3. Automated testing in isolated containers
+4. Version validation and dependency checking
+5. Automatic deployment to staging/production
+
+---
+
+## 🔐 Authentication & Authorization Flow
+
+### 🎓 Auth Fundamentals for Backend Systems
+
+**Authentication vs Authorization**:
+- **Authentication**: "Who are you?" (identity verification)
+- **Authorization**: "What can you do?" (permission checking)
+
+**Stateless Authentication**: Unlike session-based auth (server stores user state), JWT (JSON Web Token) tokens contain all user info:
+- **JWT (JSON Web Token) Structure**: Header.Payload.Signature (like a signed document)
+- **Verification**: Cryptographic signature proves token wasn't tampered with
+- **Scalability**: No server-side session storage needed
+
+**Multi-Tenant Systems**: This system serves multiple types of users (registry users vs API customers) with different permission models:
+- **Firebase Users**: Registry developers who publish nodes
+- **API Customers**: Businesses using AI (Artificial Intelligence) proxy services  
+- **Publishers**: Organizations with multiple collaborators
+
+**Authorization Patterns**:
+- **Role-Based**: Users have roles (admin/viewer) with preset permissions
+- **Resource-Based**: Permissions tied to specific entities (can edit *this* node)
+- **Context-Aware**: Permissions depend on request context (IP (Internet Protocol) whitelist, rate limits)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant LoadBalancer
+    participant AuthMiddleware
+    participant Firebase
+    participant Database
+    participant BusinessLogic
+
+    Client->>+LoadBalancer: Request with Bearer Token
+    LoadBalancer->>+AuthMiddleware: Forward Request
+    
+    AuthMiddleware->>+Firebase: Validate JWT Token
+    Firebase-->>-AuthMiddleware: User Claims
+    
+    AuthMiddleware->>+Database: Upsert User Record
+    Database-->>-AuthMiddleware: User Entity
+    
+    AuthMiddleware->>AuthMiddleware: Check User Status & Permissions
+    
+    alt User Active & Authorized
+        AuthMiddleware->>+BusinessLogic: Request with User Context
+        BusinessLogic-->>-AuthMiddleware: Response
+        AuthMiddleware-->>-LoadBalancer: Success Response
+    else User Banned/Unauthorized
+        AuthMiddleware-->>-LoadBalancer: 401/403 Error
+    end
+    
+    LoadBalancer-->>-Client: Final Response
+```
+
+**Multi-Layer Security:**
+- **Firebase JWT Validation**: Cryptographic signature verification
+- **User Status Checks**: Active/banned status enforcement  
+- **Publisher Permissions**: Granular access control (admin/collaborator/viewer)
+- **API Key Management**: Customer-specific keys for API proxy access
+- **Rate Limiting**: Per-customer and per-endpoint throttling
+- **Audit Logging**: Complete activity tracking for compliance
+
+---
+
+## 🏗️ Infrastructure & Deployment
+
+### 🎓 Cloud Infrastructure Concepts
+
+**Traditional vs Cloud-Native**:
+- **Traditional**: Physical servers, manual scaling, ops team manages hardware
+- **Cloud-Native**: Managed services, auto-scaling, infrastructure as code
+
+**Container Orchestration**: Unlike deploying directly to VMs (Virtual Machines), containers provide:
+- **Consistency**: Same environment from dev to prod
+- **Scalability**: Create/destroy instances based on load
+- **Isolation**: Apps can't interfere with each other
+- **Resource Efficiency**: Better utilization than full VMs (Virtual Machines)
+
+**Managed Services vs Self-Hosted**:
+- **Database**: Cloud SQL (Structured Query Language) vs managing PostgreSQL yourself
+- **Message Queues**: Pub/Sub (Publish/Subscribe) vs running Redis/RabbitMQ
+- **Load Balancing**: Cloud Load Balancer vs nginx configuration
+- **Monitoring**: New Relic vs Prometheus + Grafana setup
+
+**Infrastructure as Code (IaC - Infrastructure as Code)**: Terraform files in `infrastructure/` define cloud resources declaratively:
+- **Version Control**: Infrastructure changes are code-reviewed
+- **Reproducibility**: Spin up identical environments for testing
+- **Rollback**: Git revert infrastructure changes
+- **Documentation**: Infrastructure self-documents through code
+
+**Blue-Green Deployment**: Zero-downtime deployments by:
+1. Deploy new version alongside old (blue/green)
+2. Route small percentage of traffic to new version
+3. Monitor metrics, gradually shift all traffic
+4. Keep old version ready for instant rollback
+
+### Google Cloud Platform Architecture
+
+```mermaid
+graph TB
+    subgraph "Production Environment"
+        subgraph "Compute"
+            CR_PROD[Cloud Run Production]
+            CS_PROD[Cloud Scheduler]
+            CF_PROD[Cloud Functions]
+        end
+        
+        subgraph "Data"
+            DB_PROD[(Cloud SQL PostgreSQL)]
+            STORAGE_PROD[Cloud Storage Buckets]
+            PUBSUB_PROD[Pub/Sub Topics]
+        end
+        
+        subgraph "Network"
+            LB_PROD[Load Balancer]
+            CDN_PROD[Cloud CDN]
+            DNS_PROD[Cloud DNS]
+        end
+    end
+    
+    subgraph "Staging Environment"
+        CR_STAGING[Cloud Run Staging]
+        DB_STAGING[(Cloud SQL PostgreSQL)]
+        STORAGE_STAGING[Cloud Storage Buckets]
+    end
+    
+    subgraph "CI/CD Pipeline"
+        GITHUB[GitHub Repository]
+        CB[Cloud Build]
+        AR[Artifact Registry]
+        CD[Cloud Deploy]
+    end
+    
+    subgraph "Monitoring & Security"
+        NR[New Relic APM]
+        LOGS[Cloud Logging]
+        SEC[Cloud Security Scanner]
+    end
+    
+    GITHUB --> CB
+    CB --> AR
+    AR --> CD
+    CD --> CR_STAGING
+    CD -.-> CR_PROD
+    
+    CR_PROD --> DB_PROD
+    CR_PROD --> STORAGE_PROD
+    CR_PROD --> PUBSUB_PROD
+    
+    LB_PROD --> CR_PROD
+    CDN_PROD --> LB_PROD
+    
+    CR_PROD --> NR
+    CR_STAGING --> NR
+```
+
+### Terraform Infrastructure as Code
+
+**Module Structure:**
+- **`compute/`**: Cloud Run services, Cloud Functions, storage buckets
+- **`network/`**: Load balancers, CDN, DNS configuration  
+- **`alert/`**: Monitoring alerts for all services (deploy, scheduler, registry)
+- **`cicd/`**: Build triggers, artifact registries, deployment pipelines
+
+**Environment Management:**
+- **Staging**: Automatic deployment from `main` branch
+- **Production**: Manual promotion via Cloud Deploy
+- **Local Development**: Docker Compose with Supabase
+
+### Deployment Pipeline
+
+1. **Build Phase**: 
+   - Multi-stage Docker build with Go 1.23.6
+   - Dependency caching for faster builds
+   - Static binary compilation for minimal Alpine image
+
+2. **Migration Phase**:
+   - Atlas-managed database migrations
+   - Automatic schema validation
+   - Rollback capability for failed migrations
+
+3. **Deployment Phase**:
+   - Blue-green deployment via Cloud Run
+   - Health checks and gradual traffic shifting
+   - Automatic rollback on deployment failure
+
+---
+
+## 🔍 API Design & Proxy Architecture
+
+### OpenAPI-First Development
+The system follows an **OpenAPI 3.0 specification-driven** approach:
+
+- **Code Generation**: Automatic client/server code generation via `oapi-codegen`
+- **Contract Testing**: Schema validation ensures API consistency
+- **Documentation**: Living documentation that stays in sync with implementation
+
+### API Proxy Pattern
+
+```mermaid
+sequenceDiagram
+    participant Client as ComfyUI Client
+    participant Proxy as API Proxy
+    participant Auth as Authentication
+    participant Billing as Billing Service
+    participant Provider as AI Provider
+    participant Metrics as Usage Tracking
+
+    Client->>+Proxy: POST /proxy/openai/chat/completions
+    Proxy->>+Auth: Validate API Key
+    Auth-->>-Proxy: Customer Context
+    
+    Proxy->>+Billing: Check Usage Limits
+    Billing-->>-Proxy: Quota Available
+    
+    Proxy->>Proxy: Transform Request Headers
+    Proxy->>+Provider: Forward to OpenAI API
+    Provider-->>-Proxy: Response
+    
+    Proxy->>+Metrics: Record Usage
+    Metrics-->>-Proxy: Logged
+    
+    Proxy->>+Billing: Update Usage Counters
+    Billing-->>-Proxy: Updated
+    
+    Proxy-->>-Client: Proxied Response
+```
+
+**Proxy Benefits:**
+- **Unified Billing**: Single invoice across 15+ AI providers
+- **Rate Limiting**: Customer-specific quotas and throttling
+- **Usage Analytics**: Detailed per-customer, per-provider metrics
+- **Error Handling**: Standardized error responses and retry logic
+- **Authentication**: Single API key for all providers
+
+---
+
+## 📈 Performance & Scalability
+
+### 🎓 Backend Performance Concepts
+
+**Caching Layers**: Unlike frontend caching (browser cache, CDN - Content Delivery Network), backend systems have multiple cache levels:
+- **Application Cache**: In-memory data (Ristretto) for frequently accessed objects
+- **Database Query Cache**: PostgreSQL keeps query results in memory
+- **CDN (Content Delivery Network) Cache**: Geographic distribution of static assets
+- **Cache Invalidation**: "There are only two hard things..." - keeping cache consistent
+
+**Database Performance**:
+- **Indexing**: B-tree structures for fast lookups (like sorted arrays for O(log n) search)
+- **Connection Pooling**: Reuse database connections (expensive to create)
+- **Query Optimization**: EXPLAIN ANALYZE shows query execution plans
+- **Read Replicas**: Route read queries to separate DB (Database) instances
+
+**Horizontal vs Vertical Scaling**:
+- **Vertical**: Bigger servers (more CPU/RAM - Central Processing Unit/Random Access Memory) - easier but has limits
+- **Horizontal**: More servers - harder but unlimited scaling
+- **Stateless Design**: Required for horizontal scaling (any server can handle any request)
+
+**Load Balancing Algorithms**:
+- **Round Robin**: Requests distributed evenly across servers
+- **Least Connections**: Route to server with fewest active requests  
+- **Geographic**: Route based on client location
+
+### Caching Strategy
+- **Ristretto In-Memory Cache**: Hot data (user sessions, node metadata)
+- **HTTP (HyperText Transfer Protocol) Response Caching**: CDN (Content Delivery Network)-level caching for static content
+- **Database Query Optimization**: Proper indexing and query planning
+
+### Horizontal Scaling
+- **Stateless Design**: No server-side session storage
+- **Cloud Run Auto-scaling**: Automatic scaling based on request volume
+- **Database Connection Pooling**: Efficient connection management
+
+### Monitoring & Observability
+- **New Relic APM (Application Performance Monitoring)**: Application performance monitoring
+- **Custom Metrics**: Business-specific KPIs (Key Performance Indicators - node downloads, API usage)
+- **Structured Logging**: JSON (JavaScript Object Notation) logs with correlation IDs
+- **Distributed Tracing**: Request flow across services
+
+---
+
+## 🧪 Testing Strategy
+
+### Multi-Layer Testing Approach
+
+1. **Unit Tests**: Business logic validation with mocks
+2. **Integration Tests**: Database and external service integration via Testcontainers
+3. **Contract Testing**: OpenAPI (Open Application Programming Interface) schema validation
+4. **End-to-End Testing**: Critical user journeys
+
+### Test Infrastructure
+- **Testcontainers**: Isolated PostgreSQL instances for integration tests
+- **Mock Services**: Generated mocks for external dependencies
+- **Test Data Management**: SQL (Structured Query Language) fixtures and factory patterns
+
+---
+
+## 🚨 Security & Compliance
+
+### Data Protection
+- **Encryption**: TLS (Transport Layer Security) 1.3 for data in transit, AES (Advanced Encryption Standard)-256 for data at rest
+- **PII (Personally Identifiable Information) Handling**: Minimal collection, secure processing, GDPR (General Data Protection Regulation) compliance
+- **API (Application Programming Interface) Key Security**: Hashed storage, prefix-based identification
+
+### Security Scanning
+- **Node Package Scanning**: Private Google Cloud Function for vulnerability detection
+- **Dependency Scanning**: Automated checks for known vulnerabilities
+- **Container Security**: Minimal Alpine-based images with security updates
+
+### Audit & Compliance
+- **Audit Logging**: Complete activity tracking with immutable logs
+- **Access Controls**: Role-based permissions with principle of least privilege
+- **Data Retention**: Configurable retention policies for different data types
+
+---
+
+## 🎯 Business Impact & Metrics
+
+### Registry Ecosystem
+- **Node Packages**: 1000+ published packages
+- **Downloads**: Millions of node installations
+- **Publishers**: Hundreds of active developers
+- **Reviews**: Community-driven quality assessment
+
+### API Proxy Usage
+- **Requests**: Millions of API (Application Programming Interface) calls proxied monthly
+- **Cost Savings**: 20-30% reduction in AI (Artificial Intelligence) API costs through aggregation
+- **Providers**: 15+ AI services unified under single interface
+- **Uptime**: 99.9% availability SLA (Service Level Agreement)
+
+---
+
+## 🔮 Future Architecture Considerations
+
+### Planned Enhancements
+1. **GraphQL (Graph Query Language) API**: More flexible client queries
+2. **WebSocket Support**: Real-time notifications and updates
+3. **Edge Computing**: Regional API proxying for reduced latency
+4. **Machine Learning**: Intelligent node recommendations and categorization
+
+### Scalability Roadmap
+1. **Database Sharding**: Horizontal partitioning for massive scale
+2. **Event Sourcing**: Immutable event log for audit and replay capabilities
+3. **CQRS (Command Query Responsibility Segregation) Pattern**: Separate read/write models for optimized performance
+4. **Microservices**: Further decomposition for team autonomy
+
+---
+
+This architecture represents a modern, cloud-native approach to building a developer platform that balances performance, security, and developer experience while maintaining operational simplicity and cost efficiency.

--- a/.claude/commands/research/STUDY-current-repo.md
+++ b/.claude/commands/research/STUDY-current-repo.md
@@ -1,0 +1,53 @@
+# ABSORB File Command
+
+Your task is to read and deeply absorb the repository analysis guide for the current working directory. This information will be used consistently throughout our upcoming tasks, so thorough understanding is critical.
+
+## Repository Analysis Integration
+
+This command integrates with the ANALYZE-repo-for-claude storage system:
+
+1. **Check for existing analysis**: Look for the repository analysis in `~/project-summaries-for-agents/`
+   - Read `filepath-mapping.json` to find the summary folder for the current working directory
+   - If no mapping exists, inform the user they need to run the ANALYZE-repo-for-claude command first
+
+2. **Load repository guide**: Once the analysis folder is identified, read the comprehensive repository guide
+
+## Instructions
+
+1. **Locate repository analysis**: 
+   - Check if the current working directory has an existing analysis
+   - Use the filepath mapping system to find the correct summary folder
+   - If not found, stop and inform the user to run ANALYZE-repo-for-claude first
+
+2. **Read the repository guide thoroughly**: Access the analysis file and understand:
+   - The repository's purpose and context
+   - Technology stack and architecture patterns
+   - Development workflow and critical guidelines
+   - Directory structure and key files
+   - Common development tasks and procedures
+
+3. **Absorb the information**: Process and internalize the content so you can:
+   - Reference specific development patterns when needed
+   - Apply the repository's conventions to related tasks
+   - Make connections between different project components
+   - Maintain consistency with the established architectural patterns
+   - Follow the documented development guidelines
+
+4. **Confirm understanding**: Provide a brief summary showing you've absorbed the key repository information, but keep it concise - the goal is absorption, not extensive explanation.
+
+## Expected Behavior
+
+- Verify repository analysis exists before proceeding
+- Read the comprehensive repository guide completely and carefully
+- Think deeply about the architectural patterns and development conventions
+- Store the information for consistent use in subsequent tasks
+- Acknowledge completion with a focused summary of key development guidelines
+
+## Error Handling
+
+If no repository analysis is found:
+- Inform the user that no analysis exists for the current repository
+- Suggest running the ANALYZE-repo-for-claude command first
+- Do not proceed with file absorption until the analysis is available
+
+This command is designed for building comprehensive repository context that will inform all future development work in the session.

--- a/.claude/commands/team/TEAM-team-standup-analysis.md
+++ b/.claude/commands/team/TEAM-team-standup-analysis.md
@@ -1,0 +1,137 @@
+# Team Standup Analysis & Strategic Recommendations
+
+You are the Chief of Staff for a fast-growing tech team. Your role is to synthesize team activity across multiple channels and provide strategic guidance to keep the team focused on high-impact "rock projects."
+
+## Task Overview
+
+Analyze the team's current work and provide strategic recommendations by:
+
+1. **Data Collection**: Gather information from Notion standup docs and Slack channels
+2. **Synthesis**: Organize information into themes, milestones, and throughlines  
+3. **Strategic Analysis**: Provide actionable recommendations focused on rock projects
+4. **Collaboration Improvement**: Suggest ways to enhance team coordination
+
+## Instructions
+
+<instructions>
+### Step 1: Initialize Planning
+Use the TodoWrite tool to create a comprehensive task plan before starting data collection.
+
+### Step 2: Data Collection
+
+**Notion Documents:**
+- Access the Team Standup document: https://www.notion.so/drip-art/Team-Standup-1419af591e2b47a4b88af01997f5e0fa
+- Access the Roadmap document: https://www.notion.so/drip-art/02-25-25-Comfy-Roadmap-1a66d73d36508024bab9c78f137ee189#1a66d73d365080c4a257d21dc9962110
+- Extract past week's task view and identify core/rock projects from templates
+
+**Slack Channels:**
+- Read recent messages (past week) from: general, frontend, backend, temp-api-nodes, random
+- Focus on project updates, blockers, decisions, and team coordination
+
+### Step 3: Analysis & Synthesis
+
+**Organize findings into:**
+- **Current Initiatives**: What the team is actively working on
+- **Rock Projects**: Core strategic initiatives (90% focus target)
+- **Support Work**: Necessary but non-core activities  
+- **Blockers & Dependencies**: Issues slowing progress
+- **Team Coordination Patterns**: How teams are collaborating
+
+### Step 4: Strategic Recommendations
+
+**Focus Areas:**
+1. **Rock Project Prioritization**: Ensure 90% time allocation to core projects
+2. **Resource Allocation**: Identify misaligned efforts
+3. **Collaboration Improvements**: Specific suggestions for better coordination
+4. **Risk Mitigation**: Address blockers and dependencies
+5. **Weekly Priorities**: What should be prioritized this week
+
+### Step 5: Generate Report
+
+Create a comprehensive markdown file with your analysis and recommendations:
+- Save as `team-standup-analysis-[DATE].md` in the current directory
+- Use the output format specified below
+- Include executive summary at the top for quick scanning
+- Ensure all recommendations are specific and actionable
+
+</instructions>
+
+## Output Format
+
+Structure your analysis using these XML tags:
+
+<current_state>
+**Team Activity Summary**
+- Brief overview of what happened last week
+- Key accomplishments and decisions
+- Resource allocation patterns
+</current_state>
+
+<rock_projects>
+**Core Strategic Initiatives (Target: 90% effort)**
+- List of rock projects from roadmap/standup templates
+- Current status and progress
+- Resource allocation assessment
+</rock_projects>
+
+<support_work>
+**Non-Core Activities (Target: 10% effort)**
+- Maintenance, support, and overhead work
+- Assessment of time allocation vs. target
+</support_work>
+
+<themes_and_patterns>
+**Organizational Insights**
+- Recurring themes across channels
+- Cross-team dependencies
+- Communication patterns
+- Emerging opportunities or risks
+</themes_and_patterns>
+
+<blockers_dependencies>
+**Critical Issues**
+- Technical blockers
+- Resource constraints
+- Decision bottlenecks
+- External dependencies
+</blockers_dependencies>
+
+<recommendations>
+**Strategic Actions for This Week**
+
+**Immediate Priorities (This Week):**
+- [ ] Specific actions with owners and deadlines
+- [ ] Resource reallocation decisions
+- [ ] Blocker resolution plans
+
+**Focus Optimization:**
+- [ ] Activities to stop/reduce (move away from non-rock projects)
+- [ ] Activities to start/increase (double down on rock projects)
+- [ ] Process improvements for better rock project focus
+
+**Collaboration Improvements:**
+- [ ] Communication workflow optimizations
+- [ ] Cross-team coordination suggestions
+- [ ] Tool or process recommendations
+
+**Risk Mitigation:**
+- [ ] Dependency management actions
+- [ ] Backup plans for critical blockers
+- [ ] Early warning systems for future issues
+</recommendations>
+
+<success_metrics>
+**How to Measure Progress**
+- Key indicators that rock project focus is improving
+- Weekly checkpoints for course correction
+- Red flags that indicate drift from strategic priorities
+</success_metrics>
+
+## Important Context
+
+- **Rock Projects**: These are the core strategic initiatives that drive the business forward
+- **90/10 Rule**: Team should spend 90% time on rock projects, 10% on everything else
+- **Historical Challenge**: Team has struggled with rock project focus in the past
+- **Actionable Over Explanatory**: Provide specific, implementable recommendations rather than general observations
+
+Remember: Your goal is to be the strategic compass that keeps this high-performing team laser-focused on what matters most.


### PR DESCRIPTION
Organize all Claude Code commands into logical categorical subdirectories for better navigation and maintainability.

## Changes
- Create subdirectories: agents/, github/, notion/, analysis/, research/, team/
- Move all existing commands to appropriate categories
- Update README to reflect new structure with corrected file paths

This improves organization and makes it easier for team members to find relevant commands.