### PR TITLE
[docs] Add reference to Awesome Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A collection of reusable Claude Code commands for the Comfy-Org team to streamline development workflows.
 
+> **💡 Looking for more commands?** Check out [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code) - a community collection of general-purpose Claude Code commands!
+
 ## Quick Start
 
 Commands are stored in `.claude/commands/` and can be invoked using `/project:command-name` or `/user:command-name`.


### PR DESCRIPTION
Add prominent reference to the community's Awesome Claude Code collection.

## Changes
- Add eye-catching callout near the top of README for better visibility
- Link to community collection of general-purpose Claude Code commands
- Help team members discover additional useful commands beyond our org-specific ones

This provides immediate value to anyone browsing the README by directing them to a broader collection of commands while keeping our focus on Comfy-Org specific workflows.