### PR TITLE
[config] Make filepath-mapping.json user-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 
 # Logs
 *.log
+
+# User-specific configuration
+project-summaries-for-agents/filepath-mapping.json

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Commands are stored in `.claude/commands/` and can be invoked using `/project:co
 1. Clone this repository
 2. Commands are automatically available in your Claude Code session when working in this project
 3. To make commands globally available, copy desired command files to `~/.claude/commands/`
+4. **Set up filepath mapping** (required for repository analysis commands):
+   ```bash
+   cd project-summaries-for-agents
+   cp filepath-mapping.json.template filepath-mapping.json
+   # Edit filepath-mapping.json with your local repository paths
+   ```
+   See [project-summaries-for-agents/README.md](project-summaries-for-agents/README.md) for details.
 
 ## Creating New Commands
 

--- a/project-summaries-for-agents/filepath-mapping.json.template
+++ b/project-summaries-for-agents/filepath-mapping.json.template
@@ -1,0 +1,6 @@
+{
+  "/path/to/your/project1": "project1-folder-name",
+  "/path/to/your/project2": "project2-folder-name",
+  "/path/to/ComfyUI": "ComfyUI",
+  "/path/to/ComfyUI_frontend": "ComfyUI_frontend"
+}


### PR DESCRIPTION
Makes filepath-mapping.json untracked to prevent conflicts when users have different local repository paths. Provides template file and setup instructions.