### PR TITLE
[improvement] Add semantic branch validation to PR submission command

### DIFF
--- a/.claude/commands/github/PR-submit-local-as-new-pr.md
+++ b/.claude/commands/github/PR-submit-local-as-new-pr.md
@@ -11,32 +11,50 @@ The user has been working on changes and is ready to submit them as a new pull r
 Follow these steps systematically to create a clean PR:
 
 ### 1. Repository State Assessment
-First, analyze the current git state:
+First, analyze the current git state comprehensively:
 - Run `git status` to see current changes and branch
 - Run `git log --oneline -5` to understand recent commits
+- Run `git log --oneline origin/master..HEAD` to preview what commits would be included in the PR
 - Check if we're on an appropriate feature branch or need to create one
 
-### 2. Branch Management
-Handle branching based on current state:
+### 2. Branch Semantic Validation
+Evaluate if the current branch is appropriate for the changes:
+- **Analyze branch name**: Does it semantically match the type of change being made?
+  - For documentation changes: branch should contain `docs/`, `doc/`, or similar
+  - For bug fixes: branch should contain `fix/`, `bugfix/`, or similar
+  - For features: branch should contain `feat/`, `feature/`, or similar
+- **Review commit preview**: Check if existing commits on the branch are related to current changes
+- **If mismatch detected**: Recommend creating a new branch even if on a feature branch
 
-**If on main/master branch OR changes mixed with unrelated work:**
+### 3. Branch Management
+Handle branching based on semantic validation:
+
+**If on main/master branch OR branch semantically unrelated to changes:**
 - Identify and stash only the current session's changes with a clear stash message
 - Checkout main/master and ensure it's up to date (`git fetch && git pull`)
-- Create a new descriptive feature branch following naming conventions
+- Create a new descriptive feature branch that matches the change type
 - Apply the stashed changes (`git stash pop`)
 
-**If already on a clean feature branch:**
-- Verify the branch name is descriptive and appropriate
+**If already on a semantically appropriate feature branch:**
+- Verify no unrelated commits will be included (`git log origin/master..HEAD`)
 - Ensure it's based on the latest main/master
+- Confirm all commits align with the intended PR purpose
 
-### 3. Commit Creation
+### 4. Pre-Commit Validation
+Before committing, show the user what will be included:
+- Display all changes that would be in the PR: `git diff origin/master...HEAD`
+- List all commits that would be included: `git log --oneline origin/master..HEAD`
+- **Ask for confirmation**: "These changes and commits will be included in the PR. Does this look correct?"
+- If user identifies issues, guide them through cleanup (cherry-pick, rebase, or new branch)
+
+### 5. Commit Creation
 Create a meaningful commit:
 - Stage relevant changes carefully (avoid staging unrelated files)
 - Write a clear, concise commit message following repository conventions
 - Use the format: `[type] brief description` (e.g., `[feat] add user authentication`, `[fix] resolve login timeout issue`)
 - Ensure the commit message explains the "why" not just the "what"
 
-### 4. Push and PR Creation
+### 6. Push and PR Creation
 Handle repository type appropriately:
 
 **For public repositories:**
@@ -49,7 +67,7 @@ Handle repository type appropriately:
 - Push the branch: `git push -u origin <branch-name>`
 - Provide the user with the suggested PR title and description for manual creation
 
-### 5. Cleanup and Restoration
+### 7. Cleanup and Restoration
 If changes were stashed from another branch:
 - Return to the original branch
 - Restore any unrelated changes that were stashed
@@ -59,6 +77,9 @@ If changes were stashed from another branch:
 
 ## Validation Steps
 Before completing, verify:
+- [ ] Branch name semantically matches the changes being made
+- [ ] All commits in the PR are related to the intended change
+- [ ] No unrelated commits from other work are included
 - [ ] All intended changes are committed
 - [ ] No unintended files are included
 - [ ] Commit message is clear and follows conventions
@@ -68,6 +89,8 @@ Before completing, verify:
 
 ## Error Handling
 If you encounter issues:
+- **Semantic mismatch**: When branch name doesn't match change type, always recommend creating a new branch
+- **Unrelated commits detected**: Offer to cherry-pick only relevant commits to a new branch
 - **Merge conflicts**: Guide through resolution before proceeding
 - **Permission errors**: Check repository access and suggest alternative approaches
 - **Branch naming conflicts**: Suggest alternative branch names

--- a/.claude/commands/github/PR-submit-local-as-new-pr.md
+++ b/.claude/commands/github/PR-submit-local-as-new-pr.md
@@ -11,50 +11,33 @@ The user has been working on changes and is ready to submit them as a new pull r
 Follow these steps systematically to create a clean PR:
 
 ### 1. Repository State Assessment
-First, analyze the current git state comprehensively:
+First, analyze the current git state:
 - Run `git status` to see current changes and branch
 - Run `git log --oneline -5` to understand recent commits
-- Run `git log --oneline origin/master..HEAD` to preview what commits would be included in the PR
 - Check if we're on an appropriate feature branch or need to create one
 
-### 2. Branch Semantic Validation
-Evaluate if the current branch is appropriate for the changes:
-- **Analyze branch name**: Does it semantically match the type of change being made?
-  - For documentation changes: branch should contain `docs/`, `doc/`, or similar
-  - For bug fixes: branch should contain `fix/`, `bugfix/`, or similar
-  - For features: branch should contain `feat/`, `feature/`, or similar
-- **Review commit preview**: Check if existing commits on the branch are related to current changes
-- **If mismatch detected**: Recommend creating a new branch even if on a feature branch
+### 2. Branch Management
+Handle branching based on current state:
 
-### 3. Branch Management
-Handle branching based on semantic validation:
-
-**If on main/master branch OR branch semantically unrelated to changes:**
+**If on main/master branch OR changes mixed with unrelated work:**
 - Identify and stash only the current session's changes with a clear stash message
 - Checkout main/master and ensure it's up to date (`git fetch && git pull`)
-- Create a new descriptive feature branch that matches the change type
+- Create a new descriptive feature branch following naming conventions
 - Apply the stashed changes (`git stash pop`)
 
-**If already on a semantically appropriate feature branch:**
-- Verify no unrelated commits will be included (`git log origin/master..HEAD`)
+**If already on a clean feature branch:**
+- Verify the branch name is descriptive and appropriate
 - Ensure it's based on the latest main/master
-- Confirm all commits align with the intended PR purpose
+- Ensure this clean branch does not mix seemingly unrelated changes
 
-### 4. Pre-Commit Validation
-Before committing, show the user what will be included:
-- Display all changes that would be in the PR: `git diff origin/master...HEAD`
-- List all commits that would be included: `git log --oneline origin/master..HEAD`
-- **Ask for confirmation**: "These changes and commits will be included in the PR. Does this look correct?"
-- If user identifies issues, guide them through cleanup (cherry-pick, rebase, or new branch)
-
-### 5. Commit Creation
+### 3. Commit Creation
 Create a meaningful commit:
 - Stage relevant changes carefully (avoid staging unrelated files)
 - Write a clear, concise commit message following repository conventions
 - Use the format: `[type] brief description` (e.g., `[feat] add user authentication`, `[fix] resolve login timeout issue`)
 - Ensure the commit message explains the "why" not just the "what"
 
-### 6. Push and PR Creation
+### 4. Push and PR Creation
 Handle repository type appropriately:
 
 **For public repositories:**
@@ -67,7 +50,7 @@ Handle repository type appropriately:
 - Push the branch: `git push -u origin <branch-name>`
 - Provide the user with the suggested PR title and description for manual creation
 
-### 7. Cleanup and Restoration
+### 5. Cleanup and Restoration
 If changes were stashed from another branch:
 - Return to the original branch
 - Restore any unrelated changes that were stashed
@@ -77,9 +60,6 @@ If changes were stashed from another branch:
 
 ## Validation Steps
 Before completing, verify:
-- [ ] Branch name semantically matches the changes being made
-- [ ] All commits in the PR are related to the intended change
-- [ ] No unrelated commits from other work are included
 - [ ] All intended changes are committed
 - [ ] No unintended files are included
 - [ ] Commit message is clear and follows conventions
@@ -89,8 +69,6 @@ Before completing, verify:
 
 ## Error Handling
 If you encounter issues:
-- **Semantic mismatch**: When branch name doesn't match change type, always recommend creating a new branch
-- **Unrelated commits detected**: Offer to cherry-pick only relevant commits to a new branch
 - **Merge conflicts**: Guide through resolution before proceeding
 - **Permission errors**: Check repository access and suggest alternative approaches
 - **Branch naming conflicts**: Suggest alternative branch names


### PR DESCRIPTION
Improves the PR submission command to prevent contamination from unrelated commits by validating branch names match the type of changes being made.