### PR TITLE
[validation] Add frontend-specific validation commands

### DIFF
--- a/.claude/commands/validation/frontend/scan-comfy-conventions.md
+++ b/.claude/commands/validation/frontend/scan-comfy-conventions.md
@@ -1,0 +1,138 @@
+# Scan ComfyUI Frontend Conventions
+
+I need to check ComfyUI-specific frontend conventions and patterns for: $ARGUMENTS
+
+## Your Task
+
+Validate adherence to ComfyUI frontend conventions, PrimeVue patterns, and project-specific best practices.
+
+## Execution Steps
+
+1. **PrimeVue Deprecated Component Usage**
+   - `Dropdown` should be `Select` (import from 'primevue/select')
+   - `OverlayPanel` should be `Popover` (import from 'primevue/popover')
+   - `Calendar` should be `DatePicker` (import from 'primevue/datepicker')
+   - `InputSwitch` should be `ToggleSwitch` (import from 'primevue/toggleswitch')
+   - `Sidebar` should be `Drawer` (import from 'primevue/drawer')
+   - `Chips` should be `AutoComplete` with multiple enabled and typeahead disabled
+   - `TabMenu` should be `Tabs` without panels
+   - `Steps` should be `Stepper` without panels
+   - `InlineMessage` should be `Message` component
+
+2. **API & URL Patterns**
+   - `api.apiURL()` usage for backend API calls (/prompt, /queue, /view, etc.)
+   - `api.fileURL()` usage for static files from public folder
+   - Image previews using `api.apiURL('/view?...')`
+   - Extension loading using `api.fileURL(extensionPath)`
+   - Incorrect API URL construction patterns
+   - Hard-coded URLs instead of API helpers
+
+3. **Internationalization & User Experience**
+   - Hard-coded strings instead of `vue-i18n` usage
+   - Missing entries in `src/locales/en/main.json`
+   - User-facing text not using translation functions
+   - Non-actionable error messages
+   - Generic error messages instead of specific guidance
+
+4. **Styling & CSS Conventions**
+   - Custom CSS instead of Tailwind utility classes
+   - `dark:` prefix instead of `dark-theme:` for dark mode
+   - Missing theme-aware styling patterns
+   - Inline styles that could be Tailwind utilities
+   - CSS classes that duplicate Tailwind functionality
+
+5. **TypeScript & Code Quality**
+   - `@ts-expect-error` usage (should be avoided)
+   - `as any` type assertions (NEVER use)
+   - Type assertions as anything other than last resort
+   - `null` returns instead of `undefined`
+   - Missing type definitions for props/emits
+
+6. **Security & Safety Patterns**
+   - Raw HTML usage (`v-html`) without DOMPurify sanitization
+   - Dynamic content not validated through trusted sources
+   - Template patterns preferred over `v-html`
+   - Missing sanitization for user-generated content
+   - Unsafe innerHTML or similar patterns
+
+7. **Architecture & API Design**
+   - Clean, scalable public APIs and interfaces
+   - Domain-driven design pattern violations
+   - Extension/mod accessibility concerns
+   - Component APIs that don't restrict external access appropriately
+   - Missing abstraction layers for complex functionality
+
+8. **LiteGraph Specific Patterns**
+   - Missing `TypedArray` `subarray` usage opportunities
+   - `Rectangle` size/pos properties not sharing array buffer
+   - Complex `if` statements that could be single-line
+   - Unnecessary removal of `&&=` or `||=` operators
+   - `null` returns instead of `undefined`
+
+## Report Format
+
+```
+## ComfyUI Convention Analysis
+
+### Critical PrimeVue Migrations
+- [Component]: Using deprecated Dropdown
+  Fix: Replace with Select from 'primevue/select'
+  
+- [Component]: Using deprecated OverlayPanel  
+  Fix: Replace with Popover from 'primevue/popover'
+
+### API Pattern Violations
+- [File]: Hard-coded URL '/api/prompt'
+  Fix: Use api.apiURL('/prompt')
+  
+- [File]: Static file path '/templates/default.json'
+  Fix: Use api.fileURL('/templates/default.json')
+
+### Internationalization Issues
+- [Component]: Hard-coded string "Loading data..."
+  Fix: Use $t('common.loading') and add to main.json
+
+### TypeScript Anti-patterns
+- [File:Line]: Using 'as any' type assertion
+  Fix: NEVER use 'as any' - implement proper typing
+  
+- [File:Line]: Using @ts-expect-error
+  Fix: Address root type issue instead of suppressing
+
+### Security Concerns
+- [Component]: v-html without sanitization
+  Fix: Use DOMPurify.sanitize() or prefer template syntax
+
+### Styling Violations
+- [Component]: Custom CSS instead of Tailwind
+  Fix: Replace with utility classes
+  
+- [Component]: Using 'dark:' prefix
+  Fix: Use 'dark-theme:' prefix for consistency
+
+### Architecture Issues
+- [Component]: Public API exposes internal implementation
+  Fix: Create proper abstraction layer for extension compatibility
+
+### LiteGraph Optimizations
+- [Function]: Manual array operations
+  Fix: Use TypedArray subarray for better performance
+  
+- [Function]: Returning null instead of undefined
+  Fix: Return undefined for idiomatic JavaScript
+
+### Quick Wins
+- Migrate X deprecated PrimeVue components
+- Replace Y hard-coded URLs with API helpers
+- Add Z missing translations to main.json
+- Convert A custom CSS to Tailwind utilities
+```
+
+## Important Notes
+
+- PrimeVue component migration is high priority for compatibility
+- API URL patterns are critical for deployment flexibility  
+- All user-facing text must use vue-i18n for internationalization
+- NEVER use `as any` or suppress TypeScript errors
+- Architecture decisions must consider extension/mod compatibility
+- Focus on maintainable, scalable patterns for large user base

--- a/.claude/commands/validation/frontend/scan-performance-reactivity.md
+++ b/.claude/commands/validation/frontend/scan-performance-reactivity.md
@@ -1,0 +1,97 @@
+# Scan Performance & Reactivity
+
+I need to analyze performance and reactivity patterns for: $ARGUMENTS
+
+## Your Task
+
+Check for performance optimization, memory leaks, and proper reactivity patterns in Vue components.
+
+## Execution Steps
+
+1. **Memoization and Reactivity Patterns**
+   - Missing `computed()` for derived state
+   - Unnecessary `ref()` vs `reactive()` usage
+   - Missing memoization in expensive calculations
+   - Reactive data that should be readonly
+   - Over-reactive patterns causing unnecessary updates
+
+2. **Flush Timing and DOM Interactions**
+   - Missing `flush: 'post'` when reacting to DOM changes
+   - Watchers accessing DOM elements before they're rendered
+   - DOM-dependent reactions in wrong timing phase
+   - `nextTick()` usage vs proper flush timing
+   - Component interactions dependent on rendered elements
+
+3. **Memory Leak Prevention**
+   - Event listeners not cleaned up in `onBeforeUnmount`
+   - Timers and intervals without cleanup
+   - Async operations without cancellation
+   - Missing debounce/throttle cleanup
+   - WebSocket or EventSource connections not closed
+   - Observer patterns without unsubscription
+
+4. **VueUse Functions Utilization**
+   - Manual implementations that could use VueUse
+   - Common patterns available in VueUse library
+   - Performance-enhancing composables not utilized
+   - Missing reactive utilities for common operations
+   - Reinventing functionality available in VueUse
+
+5. **Unnecessary Re-renders**
+   - Missing `shallowRef()` for large objects
+   - Reactive objects when primitive refs suffice
+   - Missing `readonly()` for immutable data
+   - Function recreations in templates
+   - Prop mutations causing parent re-renders
+
+## Report Format
+
+```
+## Performance & Reactivity Analysis
+
+### Critical Memory Leaks
+- [Component]: Event listener not cleaned up
+  Fix: Add removeEventListener in onBeforeUnmount
+  
+- [Component]: Timer without cleanup
+  Fix: Clear interval/timeout in onBeforeUnmount
+
+### Flush Timing Issues  
+- [Watcher]: Accessing DOM before render
+  Fix: Add { flush: 'post' } to watch options
+
+### VueUse Opportunities
+- [Component]: Manual implementation of [pattern]
+  Fix: Use [VueUse function] from @vueuse/core
+  
+Available VueUse functions for common patterns:
+• DOM: useElementSize, useElementVisibility, useIntersectionObserver
+• Events: useEventListener, useKeyModifier, useMagicKeys
+• State: useLocalStorage, useSessionStorage, useToggle
+• Async: useAsyncState, useFetch, useTimeoutFn
+• Performance: useDebounceFn, useThrottleFn, useMemoize
+• Media: useMediaQuery, useBreakpoints, useDevicePixelRatio
+• Sensors: useMouse, usePointer, useSwipe, useGeolocation
+• Animation: useTransition, useSpring, useMotion
+• Utilities: useClipboard, useShare, useColorMode, useDark
+
+### Reactivity Anti-patterns
+- [Component]: Using reactive() for primitive value
+  Fix: Use ref() for single values
+  
+- [Component]: Missing computed() for derived data
+  Fix: Replace function with computed property
+
+### Performance Optimizations
+- Use shallowRef for large objects: X locations
+- Add readonly() for immutable data: Y locations  
+- Implement debounce/throttle: Z user interactions
+```
+
+## Important Notes
+
+- Emphasize VueUse functions heavily - check against comprehensive list
+- Focus on flush timing for DOM-dependent watchers
+- Memory leak prevention is critical for long-running applications
+- Consider component lifecycle when suggesting optimizations
+- Balance performance with code readability and maintainability

--- a/.claude/commands/validation/frontend/scan-vue-patterns.md
+++ b/.claude/commands/validation/frontend/scan-vue-patterns.md
@@ -1,0 +1,86 @@
+# Scan Vue 3.5 & Component Patterns
+
+I need to check Vue 3.5 composition patterns and component communication for: $ARGUMENTS
+
+## Your Task
+
+Analyze Vue components for Vue 3.5 best practices, composition API usage, and proper component communication patterns.
+
+## Execution Steps
+
+1. **Vue 3.5 Composition API Compliance**
+   - Props destructuring usage (Vue 3.5 style without `props` variable)
+   - Options API vs Composition API detection
+   - Proper `ref`, `reactive`, `computed`, `watch`, `watchEffect` usage
+   - Missing setup function or `<script setup>` tags
+   - Incorrect or mixed API patterns
+
+2. **Lifecycle Hook Timing**
+   - `onBeforeMounted` vs `onMounted` usage patterns
+   - `onBeforeUnmount` vs `onUnmount` timing considerations
+   - Missing lifecycle cleanup in `onBeforeUnmount`
+   - Incorrect lifecycle hook placement
+   - DOM-dependent operations in wrong lifecycle phase
+
+3. **Component Communication Patterns**
+   - Event-based patterns (`emit/@event-name`) for state changes/notifications
+   - `defineExpose` with refs only for imperative operations (form.validate(), modal.open(), editor.focus())
+   - Loose coupling through events vs tight coupling with exposed methods
+   - Missing or incorrect emits typing with `defineEmits<{...}>()`
+   - Prop drilling vs `provide/inject` usage
+
+4. **Props & Emits Definitions**
+   - Proper props destructuring without `props` variable
+   - Missing `defineProps<{...}>()` type definitions
+   - Better emit typing: `defineEmits<{ eventName: [payload: Type] }>()`
+   - Missing prop validators or default values
+   - Reactive props destructuring patterns
+
+5. **Dependency Injection Patterns**
+   - `provide/inject` for cross-component communication
+   - Prop drilling detection (props passed through multiple levels)
+   - Missing injection keys or type safety
+   - Overuse of provide/inject for simple parent-child communication
+   - Context vs props decision patterns
+
+## Report Format
+
+```
+## Vue 3.5 Pattern Analysis
+
+### Critical Pattern Violations
+- [Issue]: [File:Line] - [Description]
+  Fix: [Specific Vue 3.5 pattern to use]
+
+### Composition API Issues
+- [Component]: Using Options API instead of Composition API
+  Fix: Migrate to <script setup> with defineProps/defineEmits
+
+### Lifecycle Hook Problems
+- [Component]: DOM operation in onMounted should be onBeforeMounted
+  Fix: Move to appropriate lifecycle phase
+
+### Communication Anti-patterns
+- [Component]: Using expose for state changes
+  Fix: Replace with emit event for loose coupling
+  
+- [Component]: Prop drilling detected (3+ levels deep)
+  Fix: Use provide/inject for cross-component state
+
+### Props/Emits Typing
+- [Component]: Missing emit typing
+  Fix: Use defineEmits<{ eventName: [payload: Type] }>()
+
+### Quick Wins
+- Convert X components to Composition API
+- Add proper emit typing to Y components
+- Replace Z prop drilling chains with provide/inject
+```
+
+## Important Notes
+
+- Focus on Vue 3.5 destructuring patterns without `props` variable
+- Emphasize loose coupling through events over tight coupling with expose
+- Check for proper lifecycle timing, especially DOM-dependent operations
+- Validate emit typing patterns for better type safety
+- Consider component hierarchy when suggesting provide/inject vs props

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Commands are stored in `.claude/commands/` and can be invoked using `/project:co
 - [`/user:review-technical`](.claude/commands/blog/review-technical.md) - Review technical accuracy of blog posts
 - [`/user:write-draft`](.claude/commands/blog/write-draft.md) - Write first drafts of blog posts
 
+### Validation Commands
+
+#### Frontend Validation
+
+- [`/user:scan-comfy-conventions`](.claude/commands/validation/frontend/scan-comfy-conventions.md) - Check ComfyUI-specific patterns and PrimeVue usage
+- [`/user:scan-performance-reactivity`](.claude/commands/validation/frontend/scan-performance-reactivity.md) - Validate Vue performance and reactivity patterns
+- [`/user:scan-vue-patterns`](.claude/commands/validation/frontend/scan-vue-patterns.md) - Check Vue 3 best practices and anti-patterns
+
 ### Minor Precautions
 
 - [`/user:careful-of-refactor-between-msgs`](.claude/commands/minor-precautions/careful-of-refactor-between-msgs.md) - Reminder to be careful about refactoring between messages


### PR DESCRIPTION
## Summary
- Add three new frontend-specific validation commands for Vue and ComfyUI conventions
- Update README.md to document the new commands for CI compliance

## New Commands
- `scan-comfy-conventions`: Validates ComfyUI-specific patterns, PrimeVue usage, API patterns, i18n, TypeScript conventions
- `scan-performance-reactivity`: Checks Vue performance optimizations and reactivity best practices  
- `scan-vue-patterns`: Validates Vue 3 patterns, composition API usage, and common anti-patterns