### PR TITLE
[fix] Update semantic-memory-system references to claude-code-vector-memory

### DIFF
--- a/.claude/commands/agents/AGENT-memory-search.md
+++ b/.claude/commands/agents/AGENT-memory-search.md
@@ -31,7 +31,9 @@ Example:
 
 ### 3. Execute Semantic Search
 ```bash
-cd ~/semantic-memory-system
+# Navigate to claude-code-vector-memory installation
+# (Common paths: ~/claude-code-vector-memory, ~/agents/claude-code-vector-memory)
+cd [path-to-claude-code-vector-memory]
 source venv/bin/activate
 
 # Run multiple searches

--- a/.claude/commands/research/STUDY-knowledge-folder.md
+++ b/.claude/commands/research/STUDY-knowledge-folder.md
@@ -25,7 +25,7 @@ The user has curated specific research materials in knowledge folders for import
 3. **MEMORY SYSTEM INTEGRATION**
    <memory_check>
    Before analyzing new materials:
-   - Run: `~/agents/semantic-memory-system/search.sh "[current folder name]"`
+   - Run: `[path-to-claude-code-vector-memory]/search.sh "[current folder name]"`
    - Check for previous analyses of this topic
    - Present memory recap of related past work if found
    - Ask user if they want to build upon or start fresh from previous findings

--- a/.claude/commands/system/memory-health-check.md
+++ b/.claude/commands/system/memory-health-check.md
@@ -5,7 +5,7 @@ You are performing a comprehensive health check on the semantic memory system.
 ## Tasks to Complete
 
 1. **Check Database Status**
-   - Verify ChromaDB is accessible at `~/agents/semantic-memory-system/chroma_db/`
+   - Verify ChromaDB is accessible at `[path-to-claude-code-vector-memory]/chroma_db/`
    - Count total indexed summaries
    - Check for any corrupted entries
 
@@ -74,4 +74,5 @@ Present findings in a structured report:
 3. [Add metadata to: ...]
 ```
 
-Use the Python scripts at `~/agents/semantic-memory-system/scripts/` to gather this information or run `~/agents/semantic-memory-system/scripts/health_check.py` directly.
+Use the Python scripts at `[path-to-claude-code-vector-memory]/scripts/` to gather this information or run `[path-to-claude-code-vector-memory]/scripts/health_check.py` directly.
+Note: claude-code-vector-memory can be installed from https://github.com/christian-byrne/claude-code-vector-memory

--- a/.claude/commands/system/semantic-memory-search.md
+++ b/.claude/commands/system/semantic-memory-search.md
@@ -13,7 +13,7 @@ You are accessing your shared memory with this user for the task: $ARGUMENTS
 
 2. **Search Semantic Memory**
    ```bash
-   ~/agents/semantic-memory-system/search.sh "your extracted search terms"
+   [path-to-claude-code-vector-memory]/search.sh "your extracted search terms"
    ```
 
 3. **Review Results**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ This is a ONE-TIME check when you first understand the task scope. Don't repeat 
 CRITICAL: Before starting ANY new task, you MUST search through your previous conversations with this user:
 
 1. **Extract key terms** from the user's request (technologies, components, concepts)
-2. **Run semantic search**: `~/agents/semantic-memory-system/search.sh "extracted key terms"`
+2. **Run semantic search**: Use the [claude-code-vector-memory](https://github.com/christian-byrne/claude-code-vector-memory) search tool
+   - If installed, run: `[path-to-claude-code-vector-memory]/search.sh "extracted key terms"`
+   - Common installation paths: `~/claude-code-vector-memory/`, `~/agents/claude-code-vector-memory/`
 3. **Review results** and identify relevant past work
 4. **Present memory recap** to user showing what related work you've done before
 5. **Ask user** if they want to build on previous approaches or start fresh


### PR DESCRIPTION
## Summary
- Replace hardcoded `~/agents/semantic-memory-system` paths with generic `[path-to-claude-code-vector-memory]` placeholders
- Add link to the official repository for users to install from
- Make installation path flexible since users can clone the repo anywhere

## Changes
- Updated CLAUDE.md to reference the correct repository name with installation guidance
- Updated 4 command files that referenced the old path:
  - `.claude/commands/agents/AGENT-memory-search.md`
  - `.claude/commands/system/memory-health-check.md`
  - `.claude/commands/system/semantic-memory-search.md`
  - `.claude/commands/research/STUDY-knowledge-folder.md`

Fixes #24