### PR TITLE
Add Context7 MCP dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Commands are stored in `.claude/commands/` and can be invoked using `/project:co
      ./setup.sh
      ```
    - The setup script will create a virtual environment, install dependencies, build the initial index, and run a health check
+7. **Install Context7 MCP** (optional but recommended):
+   - Provides official documentation for many libraries via the `/research-with-auto-mcp` command
+   - Install the Context7 MCP server or CLI from its repository and ensure it is running locally when using research commands
 
 ## Creating New Commands
 


### PR DESCRIPTION
## Summary
- mention Context7 MCP setup in README

## Testing
- `bash /tmp/validate.sh`
- `bash /tmp/check_readme.sh`


------
https://chatgpt.com/codex/tasks/task_e_687e9e09f5c48330ab3adf5350b0fafa