### PR TITLE
[feat] Add automated command installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,11 @@ Commands are stored in `.claude/commands/` and can be invoked using `/project:co
 
 1. Clone this repository
 2. Commands are automatically available in your Claude Code session when working in this project
-3. To make commands globally available, copy desired command files to `~/.claude/commands/`
+3. **To make commands globally available**, run the installation script:
+   ```bash
+   ./install-commands.sh
+   ```
+   This creates symlinks from `.claude/commands/` to `~/.claude/commands/`, ensuring commands stay up-to-date with repository changes.
 4. **Install Gemini CLI** (required for large context analysis tasks):
    - Install from [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli)
    - Used automatically for tasks exceeding Claude's context window

--- a/install-commands.sh
+++ b/install-commands.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMANDS_DIR="$SCRIPT_DIR/.claude/commands"
+TARGET_DIR="$HOME/.claude/commands"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Installing Claude Code commands...${NC}"
+
+# Create target directory if it doesn't exist
+mkdir -p "$TARGET_DIR"
+
+# Check if commands directory exists in repo
+if [[ ! -d "$COMMANDS_DIR" ]]; then
+    echo -e "${RED}Error: Commands directory not found at $COMMANDS_DIR${NC}"
+    exit 1
+fi
+
+# Function to create symlinks
+create_symlinks() {
+    local source_dir="$1"
+    local target_dir="$2"
+    local relative_path="${3:-}"
+
+    for item in "$source_dir"/*; do
+        if [[ ! -e "$item" ]]; then
+            continue
+        fi
+
+        local basename="$(basename "$item")"
+        local target_path="$target_dir/$basename"
+        local source_path="$item"
+
+        if [[ -d "$item" ]]; then
+            # Create directory if it doesn't exist
+            mkdir -p "$target_path"
+            # Recursively create symlinks for directory contents
+            create_symlinks "$source_path" "$target_path" "$relative_path/$basename"
+        elif [[ -f "$item" ]]; then
+            # Create symlink for file
+            if [[ -L "$target_path" ]]; then
+                # Remove existing symlink
+                rm "$target_path"
+                echo -e "${YELLOW}Updating: $relative_path/$basename${NC}"
+            elif [[ -e "$target_path" ]]; then
+                # Backup existing file if not a symlink
+                mv "$target_path" "$target_path.backup"
+                echo -e "${YELLOW}Backed up existing file: $relative_path/$basename -> $relative_path/$basename.backup${NC}"
+            else
+                echo -e "${GREEN}Installing: $relative_path/$basename${NC}"
+            fi
+            ln -s "$source_path" "$target_path"
+        fi
+    done
+}
+
+# Start installation
+echo -e "${GREEN}Creating symlinks from $COMMANDS_DIR to $TARGET_DIR${NC}"
+create_symlinks "$COMMANDS_DIR" "$TARGET_DIR" ""
+
+echo -e "\n${GREEN}✓ Installation complete!${NC}"
+echo -e "${GREEN}Commands are now available globally in Claude Code${NC}"
+echo -e "${YELLOW}Note: Changes to commands in this repository will be reflected immediately${NC}"

--- a/install-commands.sh
+++ b/install-commands.sh
@@ -5,65 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMANDS_DIR="$SCRIPT_DIR/.claude/commands"
 TARGET_DIR="$HOME/.claude/commands"
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
-
-echo -e "${GREEN}Installing Claude Code commands...${NC}"
-
-# Create target directory if it doesn't exist
+echo "Installing Claude Code commands..."
 mkdir -p "$TARGET_DIR"
 
-# Check if commands directory exists in repo
-if [[ ! -d "$COMMANDS_DIR" ]]; then
-    echo -e "${RED}Error: Commands directory not found at $COMMANDS_DIR${NC}"
-    exit 1
-fi
+cp -rsf "$COMMANDS_DIR"/* "$TARGET_DIR"/
 
-# Function to create symlinks
-create_symlinks() {
-    local source_dir="$1"
-    local target_dir="$2"
-    local relative_path="${3:-}"
-
-    for item in "$source_dir"/*; do
-        if [[ ! -e "$item" ]]; then
-            continue
-        fi
-
-        local basename="$(basename "$item")"
-        local target_path="$target_dir/$basename"
-        local source_path="$item"
-
-        if [[ -d "$item" ]]; then
-            # Create directory if it doesn't exist
-            mkdir -p "$target_path"
-            # Recursively create symlinks for directory contents
-            create_symlinks "$source_path" "$target_path" "$relative_path/$basename"
-        elif [[ -f "$item" ]]; then
-            # Create symlink for file
-            if [[ -L "$target_path" ]]; then
-                # Remove existing symlink
-                rm "$target_path"
-                echo -e "${YELLOW}Updating: $relative_path/$basename${NC}"
-            elif [[ -e "$target_path" ]]; then
-                # Backup existing file if not a symlink
-                mv "$target_path" "$target_path.backup"
-                echo -e "${YELLOW}Backed up existing file: $relative_path/$basename -> $relative_path/$basename.backup${NC}"
-            else
-                echo -e "${GREEN}Installing: $relative_path/$basename${NC}"
-            fi
-            ln -s "$source_path" "$target_path"
-        fi
-    done
-}
-
-# Start installation
-echo -e "${GREEN}Creating symlinks from $COMMANDS_DIR to $TARGET_DIR${NC}"
-create_symlinks "$COMMANDS_DIR" "$TARGET_DIR" ""
-
-echo -e "\n${GREEN}✓ Installation complete!${NC}"
-echo -e "${GREEN}Commands are now available globally in Claude Code${NC}"
-echo -e "${YELLOW}Note: Changes to commands in this repository will be reflected immediately${NC}"
+echo "✓ Installation complete! Commands are now available globally in Claude Code"


### PR DESCRIPTION
Adds `install-commands.sh` to automate global command installation using symlinks. This ensures commands stay synchronized with repository updates without manual copying.

**Benefits:**
- Commands auto-update when repo is updated
- No more outdated copied commands
- Simple one-command installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)